### PR TITLE
Add alevin (no fry) test

### DIFF
--- a/R/generate_qc_report.R
+++ b/R/generate_qc_report.R
@@ -2,7 +2,7 @@
 #'
 #' @param sce A SingleCellExperiment object that the report will describe
 #' @param sample_name The name of the sample
-#' @param outfile The output file path that will be created.
+#' @param output The output file path that will be created.
 #'   If the file name does not include an extension, ".html" will be added automatically.
 #'   Any directories in the path will be created as needed.
 #'

--- a/man/generate_qc_report.Rd
+++ b/man/generate_qc_report.Rd
@@ -11,12 +11,12 @@ generate_qc_report(sce, sample_name, output = NULL)
 
 \item{sample_name}{The name of the sample}
 
-\item{outfile}{The output file path that will be created.
+\item{output}{The output file path that will be created.
 If the file name does not include an extension, ".html" will be added automatically.
 Any directories in the path will be created as needed.}
 }
 \value{
-The path of the output file
+The full path of the output file
 }
 \description{
 Generate a QC report from a SingleCellExperiment object
@@ -25,4 +25,5 @@ Generate a QC report from a SingleCellExperiment object
 \dontrun{
 generate_qc_report(my_sce, "Sample 1", output = "reports/sample1_report.html")
 }
+
 }

--- a/tests/testthat/test-read_alevin.R
+++ b/tests/testthat/test-read_alevin.R
@@ -1,33 +1,47 @@
 dir <- system.file("extdata", package="scpcaData")
+alevin_dir <- file.path(dir, "Breast_Cancer_3p_LT/alevin_txome")
 usa_dir <- file.path(dir, "Breast_Cancer_3p_LT/alevinfry_usa_filtered")
 intron_dir <- file.path(dir, "Breast_Cancer_3p_LT/alevinfry_intron_filtered")
 
-# expected matrix size
-sce_size <- c(60321, 614)
+# expected alevin matrix size
+sce_alevin_size <- c(60275, 10378)
+# expected alevin-fry matrix size
+sce_af_size <- c(60321, 614)
 
-test_that("Check that reading USA mode works", {
+test_that("reading salmon alevin data works", {
+  sce <- read_alevin(alevin_dir)
+  expect_s4_class(sce, "SingleCellExperiment")
+  expect_equal(dim(sce), sce_alevin_size)
+  # check that column names are barcodes
+  col_barcode <- str_detect(colnames(sce), "^[ACGT]+$")
+  expect_true(all(col_barcode))
+})
+
+test_that("reading alevin-fry USA mode works", {
   sce <- read_alevin(usa_dir,
                      usa_mode = TRUE,
                     which_counts = "spliced")
   expect_s4_class(sce, "SingleCellExperiment")
-  expect_equal(dim(sce), sce_size)
+  expect_equal(dim(sce), sce_af_size)
   # check that column names are barcodes
   col_barcode <- str_detect(colnames(sce), "^[ACGT]+$")
   expect_true(all(col_barcode))
+  # no remaining unspliced
   unmerged_genes <- str_subset(rownames(sce), "-[IUA]$")
   expect_length(unmerged_genes, 0)
 })
 
 
-test_that("Check that reading intron mode works", {
+test_that("reading alevin-fry intron mode works", {
   sce <- read_alevin(intron_dir,
                      intron_mode = TRUE,
                      which_counts = "unspliced")
   expect_s4_class(sce, "SingleCellExperiment")
-  expect_equal(dim(sce), sce_size)
+  expect_equal(dim(sce), sce_af_size)
   # check that column names are barcodes
   col_barcode <- stringr::str_detect(colnames(sce), "^[ACGT]+$")
   expect_true(all(col_barcode))
+  # no remaining unspliced
   unmerged_genes <- str_subset(rownames(sce), "-[IUA]$")
   expect_length(unmerged_genes, 0)
 


### PR DESCRIPTION
For completeness, we should have a test for base alevin. Now that such data is in the updated scpcaData, this test should run.

Also fixed a small documentation error that was throwing a check warning. 