### PR TITLE
Create scpcaTools docker image 

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -3,3 +3,4 @@
 ^\.github$
 ^README\.Rmd$
 ^inst/rmd/.*\.html$
+^docker$

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM rocker/r-ver:4.0.5
+LABEL maintainer="ccdl@alexslemonade.org"
+
+COPY scripts/install_scpca_deps.sh .
+
+RUN bash ./install_scpca_deps.sh
+
+##########################
+# Install scpcaTools package
+RUN Rscript -e "remotes::install_github('AlexsLemonade/scpcaTools')"
+
+# set final workdir for commands
+WORKDIR /home

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,6 @@
 FROM rocker/r-ver:4.0.5
 LABEL maintainer="ccdl@alexslemonade.org"
+LABEL org.opencontainers.image.source https://github.com/AlexsLemonade/scpcaTools
 
 COPY scripts/install_scpca_deps.sh .
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,12 @@
+This folder contains a Dockerfile to build an image with R, scpcaTools and all of its dependencies.
+
+The image is built from a versioned Rocker image, with additional R packages and other utilities added as needed.
+
+It can be built with the following command run in this directory:
+
+```
+docker build . -t ghcr.io/alexslemonade/scpca-tools
+```
+
+
+Note that this image does not include Rstudio, in attempt to make the image smaller. 

--- a/docker/README.md
+++ b/docker/README.md
@@ -9,4 +9,4 @@ docker build . -t ghcr.io/alexslemonade/scpca-tools
 ```
 
 
-Note that this image does not include Rstudio, in attempt to make the image smaller. 
+Note that this image does not include RStudio, in attempt to make the image smaller. 

--- a/docker/scripts/install_scpca_deps.sh
+++ b/docker/scripts/install_scpca_deps.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -e
+
+NCPUS=${NCPUS:-1}
+
+apt-get update && apt-get install -y --no-install-recommends \
+  apt-utils \
+  dialog
+
+# Add curl, bzip2 and dev libs
+apt-get -y --no-install-recommends install \
+    awscli \
+    bzip2 \
+    curl \
+    libbz2-dev \
+    libcairo2-dev \
+    libcurl4-openssl-dev \
+    libgdal-dev \
+    libgit2-dev \
+    libglpk-dev \
+    liblzma-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libssh2-1-dev \
+    libudunits2-dev \
+    libxml2-dev \
+    libxtst6 \
+  && rm -rf /var/lib/apt/lists/*
+
+#### R packages
+###############
+# this comes first since bioconductor packages are 
+# dependent on updated matrixStats
+install2.r --error --skipinstalled -n $NCPUS \
+    BiocManager \
+    DBI \
+    devtools \
+    here \
+    matrixStats \
+    optparse \
+    rmarkdown \
+    rprojroot \
+    RSQLite \
+    tidyverse \
+    
+
+##########################
+# Install bioconductor packages
+Rscript -e "BiocManager::install(c( \
+    'AnnotationHub', \
+    'Biostrings', \
+    'bluster', \
+    'BSgenome', \
+    'DropletUtils', \
+    'eisaR', \
+    'ensembldb', \
+    'fishpond', \
+    'GenomicFeatures', \
+    'LoomExperiment', \
+    'scran', \
+    'scater', \
+    'SingleCellExperiment', \
+    'SummarizedExperiment', \
+    'tximport'), \
+    update = FALSE)"
+
+rm -rf /tmp/downloaded_packages
+rm -rf /tmp/Rtmp*

--- a/docker/scripts/install_scpca_deps.sh
+++ b/docker/scripts/install_scpca_deps.sh
@@ -29,7 +29,7 @@ apt-get -y --no-install-recommends install \
 
 #### R packages
 ###############
-# this comes first since bioconductor packages are 
+# this comes first since bioconductor packages are
 # dependent on updated matrixStats
 install2.r --error --skipinstalled -n $NCPUS \
     BiocManager \
@@ -42,7 +42,7 @@ install2.r --error --skipinstalled -n $NCPUS \
     rprojroot \
     RSQLite \
     tidyverse \
-    
+
 
 ##########################
 # Install bioconductor packages
@@ -57,6 +57,7 @@ Rscript -e "BiocManager::install(c( \
     'fishpond', \
     'GenomicFeatures', \
     'LoomExperiment', \
+    'miQC', \
     'scran', \
     'scater', \
     'SingleCellExperiment', \

--- a/docker/scripts/install_scpca_deps.sh
+++ b/docker/scripts/install_scpca_deps.sh
@@ -56,7 +56,6 @@ Rscript -e "BiocManager::install(c( \
     'ensembldb', \
     'fishpond', \
     'GenomicFeatures', \
-    'LoomExperiment', \
     'miQC', \
     'scran', \
     'scater', \


### PR DESCRIPTION
This PR adds a Dockerfile to create an image containing scpcaTools and all of its dependencies. 

closes #32

This is similar to the one that was in `alsf-scpca`, but it is more directly tied to this repository, which will make it easier to automate building the image.  (On that front, there is a `LABEL` field that ties this image to the repo: cool!)

The main difference is that this image is derived from `r-vers`, so it does not include RStudio. Since the main use of this will be in workflows, not interactive sessions, that seemed like a reasonable overhead to remove. It does mean we have to install `tidyverse` manually, but we can leave out some of the packages that are part of the rocker tidyverse image that we don't need at all. 

The other big changes are that I moved most of the installation out to a separate script. This is to make it easier to make sure intermediate files are deleted and don't become part of the docker image (keeping it as small as we can, which is actually not that small still, unfortunately). I could split up the layers a bit to potentially speed intermediate builds, but it isn't that bad as is. Most of the time is in installing Bioconductor packages from source; everything before that is binary installs anyway.

One question is if we want to bump the R version to 4.1; I don't expect any regressions (I have tested the package locally with R 4.1, and I think the automated testing is with latest R), but nor do I expect much benefit.

