### PR TITLE
Add posterior probability from miQC to add_cell_mito_qc.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,11 +18,10 @@ Description: Tools for processing single cell data associated with the
 License: BSD_3_clause + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1.9001
+RoxygenNote: 7.1.1
 Imports: 
     BiocGenerics,
     DropletUtils,
-    flexmix,
     glue,
     jsonlite,
     magrittr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,16 +18,18 @@ Description: Tools for processing single cell data associated with the
 License: BSD_3_clause + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.1.9001
 Imports: 
     BiocGenerics,
     DropletUtils,
+    flexmix,
     glue,
     jsonlite,
     magrittr,
     Matrix,
     Matrix.utils,
     methods,
+    miQC,
     rmarkdown,
     S4Vectors,
     scater,

--- a/R/add_cell_mito_qc.R
+++ b/R/add_cell_mito_qc.R
@@ -56,6 +56,7 @@ add_cell_mito_qc <- function(sce, mito, miQC = FALSE, ...){
 
     # use filter cells, but keeping all cells, to add a column to colData with prob_compromised
     sce <- miQC::filterCells(sce, model, posterior_cutoff = 1, verbose = FALSE)
+    metadata(sce)$miQC_model <- model
   }
 
   return(sce)

--- a/R/add_cell_mito_qc.R
+++ b/R/add_cell_mito_qc.R
@@ -54,21 +54,8 @@ add_cell_mito_qc <- function(sce, mito, miQC = FALSE, ...){
     # generate linear mixture model of probability of cells being compromised
     model <- miQC::mixtureModel(sce)
 
-    # grab posterior probability from fitted model
-    # code from miQC plotModel.R lines 52-70 https://github.com/greenelab/miQC/blob/main/R/plotModel.R
-    predictions <- flexmix::fitted(model)
-    intercept1 <- flexmix::parameters(model, component = 1)[1]
-    intercept2 <- flexmix::parameters(model, component = 2)[1]
-    if (intercept1 > intercept2) {
-      compromised_dist <- 1
-    } else {
-      compromised_dist <- 2
-    }
-
-    posterior <- flexmix::posterior(model)
-
-    # add posterior probability of cells being compromised to colData
-    sce$posterior_probability <- posterior[, compromised_dist]
+    # use filter cells, but keeping all cells, to add a column to colData with prob_compromised
+    sce <- miQC::filterCells(sce, model, posterior_cutoff = 1, verbose = FALSE)
   }
 
   return(sce)

--- a/R/add_cell_mito_qc.R
+++ b/R/add_cell_mito_qc.R
@@ -2,6 +2,8 @@
 #'
 #' @param sce SingleCellExperiment object.
 #' @param mito Character vector of mitochondrial gene names in the same format as rownames of SingleCellExperiment object.
+#' @param miQC Logical indicating whether or not to calculate the posterior probability of a cell being compromised using
+#'   the linear mixture model in miQC. Default is FALSE.
 #' @param ... Any additional arguments to be passed to scater::addPerCellQC.
 #'
 #' @return SingleCellExperiment with colData slot containing calculated QC metrics.
@@ -18,7 +20,7 @@
 #'                  mito = mito_genes,
 #'                  threshold = 5)
 #' }
-add_cell_mito_qc <- function(sce, mito, ...){
+add_cell_mito_qc <- function(sce, mito, miQC = FALSE, ...){
 
   # check that input is a SingleCellExperiment
   if(!is(sce, "SingleCellExperiment")){
@@ -35,15 +37,39 @@ add_cell_mito_qc <- function(sce, mito, ...){
     warning("sce does not contain genes corresponding to the list of mito gene names")
   }
 
+  # check that miQC is logical
+  if(!is.logical(miQC)){
+    stop("miQC must be set as TRUE or FALSE")
+  }
+
   # add per cell QC with mitochondrial subset
   sce <- scater::addPerCellQC(
     sce,
     subsets = list(mito = mito[mito %in% rownames(sce)]),
     ...
   )
-  # simplify naming
-  names(colData(sce)) <- stringr::str_replace(names(colData(sce)),
-                                              "^subsets_mito_",
-                                              "mito_")
+
+
+  if(miQC){
+    # generate linear mixture model of probability of cells being compromised
+    model <- miQC::mixtureModel(sce)
+
+    # grab posterior probability from fitted model
+    # code from miQC plotModel.R lines 52-70 https://github.com/greenelab/miQC/blob/main/R/plotModel.R
+    predictions <- flexmix::fitted(model)
+    intercept1 <- flexmix::parameters(model, component = 1)[1]
+    intercept2 <- flexmix::parameters(model, component = 2)[1]
+    if (intercept1 > intercept2) {
+      compromised_dist <- 1
+    } else {
+      compromised_dist <- 2
+    }
+
+    posterior <- flexmix::posterior(model)
+
+    # add posterior probability of cells being compromised to colData
+    sce$posterior_probability <- posterior[, compromised_dist]
+  }
+
   return(sce)
 }

--- a/man/add_cell_mito_qc.Rd
+++ b/man/add_cell_mito_qc.Rd
@@ -4,12 +4,15 @@
 \alias{add_cell_mito_qc}
 \title{Calculate QC metrics for all reads and mitochondrial subset for each cell in a SingleCellExperiment}
 \usage{
-add_cell_mito_qc(sce, mito, ...)
+add_cell_mito_qc(sce, mito, miQC = FALSE, ...)
 }
 \arguments{
 \item{sce}{SingleCellExperiment object.}
 
 \item{mito}{Character vector of mitochondrial gene names in the same format as rownames of SingleCellExperiment object.}
+
+\item{miQC}{Logical indicating whether or not to calculate the posterior probability of a cell being compromised using
+the linear mixture model in miQC. Default is FALSE.}
 
 \item{...}{Any additional arguments to be passed to scater::addPerCellQC.}
 }

--- a/tests/testthat/test-add_cell_mito_qc.R
+++ b/tests/testthat/test-add_cell_mito_qc.R
@@ -7,7 +7,7 @@ test_that("Check QC addition", {
   sce <- add_cell_mito_qc(sce, mito = mito, miQC = TRUE)
   expected_cols <- c("sum", "detected", "total",
                      "subsets_mito_sum","subsets_mito_detected", "subsets_mito_percent",
-                     "posterior_probability")
+                     "prob_compromised")
   # check column names
   expect_true(all(expected_cols %in% names(colData(sce))))
   # make sure we don't get all zeros, which would indicate match failure

--- a/tests/testthat/test-add_cell_mito_qc.R
+++ b/tests/testthat/test-add_cell_mito_qc.R
@@ -4,12 +4,13 @@ sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 0)
 
 test_that("Check QC addition", {
   mito <- c(rownames(sce)[1:10], "ZZZZZZ") # include a gene that is not in the sce
-  sce <- add_cell_mito_qc(sce, mito = mito)
+  sce <- add_cell_mito_qc(sce, mito = mito, miQC = TRUE)
   expected_cols <- c("sum", "detected", "total",
-                     "mito_sum","mito_detected", "mito_percent")
+                     "subsets_mito_sum","subsets_mito_detected", "subsets_mito_percent",
+                     "posterior_probability")
   # check column names
   expect_true(all(expected_cols %in% names(colData(sce))))
   # make sure we don't get all zeros, which would indicate match failure
-  expect_gt(mean(sce$mito_percent), 0)
+  expect_gt(mean(sce$subsets_mito_percent), 0)
 
 })

--- a/tests/testthat/test-add_cell_mito_qc.R
+++ b/tests/testthat/test-add_cell_mito_qc.R
@@ -11,6 +11,7 @@ test_that("Check QC addition", {
   # check column names
   expect_true(all(expected_cols %in% names(colData(sce))))
   # make sure we don't get all zeros, which would indicate match failure
+  expect_false(is.null(metadata(sce)$miQC_model))
   expect_gt(mean(sce$subsets_mito_percent), 0)
 
 })


### PR DESCRIPTION
Closes #34. This PR adds an option to `add_cell_mito_qc.R` to add an additional column to the `colData` of the sce object that would contain the posterior probability of a cell being compromised as calculated using `miQC::model()`.  To do this I first calculated the model of the sce object, and then grabbed the probability values and added them to the `colData`. To calculate the `posterior_probability`, I took a piece of code from the [`miQC::plotModel()` function lines 52-70](https://github.com/greenelab/miQC/blob/main/R/plotModel.R#L52), where they calculate the probability of being compromised for each cell. 

In doing this, I chose to make the addition of the `posterior_probability` column optional because we will be using this function to add basic `colData` stats for both unfiltered and `emptyDrop` filtered sces. I don't think we want to add these values to the unfiltered sces, so I kept it optional. 

I also removed the modification of the `colData` columns to be compatible with `miQC` and modified the test function to ensure that the `posterior_probability` column was present. 