### PR TITLE
Use filtered and unfiltered data for QC report

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,10 +18,12 @@ Description: Tools for processing single cell data associated with the
 License: BSD_3_clause + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Imports: 
     BiocGenerics,
+    dplyr,
     DropletUtils,
+    ggplot2,
     glue,
     jsonlite,
     magrittr,

--- a/R/generate_qc_report.R
+++ b/R/generate_qc_report.R
@@ -50,8 +50,8 @@ generate_qc_report <- function(sce,
     output_file = output_file,
     output_dir = output_dir,
     params = list(
-      sce = sce,
       sample = sample_name,
+      unfiltered_sce = sce,
       filtered_sce = filtered_sce
     ),
     envir = new.env()

--- a/R/generate_qc_report.R
+++ b/R/generate_qc_report.R
@@ -1,7 +1,7 @@
 #' Generate a QC report from a SingleCellExperiment object
 #'
-#' @param sce A SingleCellExperiment object that the report will describe
-#' @param sample_name The name of the sample
+#' @param sample_name The name of the sample for report headers
+#' @param unfiltered_sce A SingleCellExperiment object that the report will describe
 #' @param filtered_sce An optional filtered single cell experiment derived from first
 #' @param output The output file path that will be created.
 #'   If the file name does not include an extension, ".html" will be added automatically.
@@ -13,11 +13,11 @@
 #'
 #' @examples
 #' \dontrun{
-#' generate_qc_report(my_sce, "Sample 1", output = "reports/sample1_report.html")
+#' generate_qc_report("Sample 1", my_sce, output = "reports/sample1_report.html")
 #' }
 #'
-generate_qc_report <- function(sce,
-                               sample_name,
+generate_qc_report <- function(sample_name,
+                               unfiltered_sce,
                                filtered_sce = NULL,
                                output = NULL){
   if(!inherits(sce, "SingleCellExperiment")){

--- a/R/generate_qc_report.R
+++ b/R/generate_qc_report.R
@@ -2,6 +2,7 @@
 #'
 #' @param sce A SingleCellExperiment object that the report will describe
 #' @param sample_name The name of the sample
+#' @param filtered_sce An optional filtered single cell experiment derived from first
 #' @param output The output file path that will be created.
 #'   If the file name does not include an extension, ".html" will be added automatically.
 #'   Any directories in the path will be created as needed.
@@ -17,9 +18,22 @@
 #'
 generate_qc_report <- function(sce,
                                sample_name,
+                               filtered_sce = NULL,
                                output = NULL){
-  if(!inherits(sce,"SingleCellExperiment")){
+  if(!inherits(sce, "SingleCellExperiment")){
     stop("`sce` must be a SingleCellExperiment object.")
+  }
+  # check that the filtered sce is as expected
+  if(!is.null(filtered_sce)){
+    if (!inherits(filtered_sce, "SingleCellExperiment")){
+      stop("`filtered_sce` must be a SingleCellExperiment object.")
+    }
+    if (ncol(sce) < ncol(filtered_sce)){
+      stop("`filtered_sce` should have fewer cells than `sce`")
+    }
+    if (!all(colnames(filtered_sce) %in% colnames(sce))){
+      "Some cells in `filtered_sce` are not present in `sce`, from which it should be derived."
+    }
   }
 
   if(is.null(output)){
@@ -37,7 +51,8 @@ generate_qc_report <- function(sce,
     output_dir = output_dir,
     params = list(
       sce = sce,
-      sample = sample_name
+      sample = sample_name,
+      filtered_sce = filtered_sce
     ),
     envir = new.env()
   )

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -1,7 +1,7 @@
 ---
 params:
   sample: Example
-  sce: !r SingleCellExperiment::SingleCellExperiment()
+  unfiltered_sce: !r scpcaTools:::sim_sce()
   filtered_sce: NULL
   date: !r Sys.Date()
 
@@ -14,36 +14,57 @@ output:
     toc_depth: 2
     toc_float: true
     number_sections: true
-    code_folding: hide
+    code_download: true
 ---
 
-```{r setup, message=FALSE}
-library(SingleCellExperiment)
+```{r setup, message = FALSE, echo = FALSE}
+# knitr options
+knitr::opts_chunk$set(
+  echo = FALSE
+)
 
+library(SingleCellExperiment)
+library(dplyr)
+library(ggplot2)
+
+# Set standard ggplot theme
+theme_set(theme_bw())
+```
+
+```{r sce_setup}
 # save some typing later
 sample <- params$sample
-sce <- params$sce
+unfiltered_sce <- params$unfiltered_sce
 filtered_sce <- params$filtered_sce
 
 has_filtered <- !is.null(filtered_sce)
+
+# if there is no filtered sce, use the unfiltered for both
+if (!has_filtered){
+  filtered_sce <- unfiltered_sce
+}
+# add cell stats if missing
+if (is.null(unfiltered_sce$sum)){
+  unfiltered_sce <- scater::addPerCellQC(unfiltered_sce)
+}
 ```
 
 # Introduction
 
 # Processing Information for `r sample`
 
-## Sample Metrics
+## Raw Sample Metrics
 
 ```{r }
 # extract sce metadata containing processing information as table
-metadata_list <- metadata(sce) 
+unfiltered_meta <- metadata(unfiltered_sce) 
 
 sample_information <- tibble::tibble(
   "Sample id" = sample,
-  "Tech version" = metadata_list$tech_version,
-  "Number of reads sequenced" = format(metadata_list$total_reads, big.mark = ',', scientific = FALSE),
-  "Number of mapped reads" = format(metadata_list$mapped_reads, big.mark = ',', scientific = FALSE),
-  "Number of cells reported by alevin-fry" = format(metadata_list$af_num_cells, big.mark = ',', scientific = FALSE)
+  "Tech version" = unfiltered_meta$tech_version,
+  "Number of reads sequenced" = format(unfiltered_meta$total_reads, big.mark = ',', scientific = FALSE),
+  "Number of mapped reads" = format(unfiltered_meta$mapped_reads, big.mark = ',', scientific = FALSE),
+  "Number of cells reported by alevin-fry" = format(unfiltered_meta$af_num_cells, big.mark = ',', scientific = FALSE)
 ) %>%
   t()
 
@@ -51,18 +72,18 @@ sample_information <- tibble::tibble(
 knitr::kable(sample_information, "simple")
 ```
 
-## Pre-Processing
+## Pre-Processing Information
 
 ```{r }
 processing_info <- tibble::tibble(
-  "Salmon version" = metadata_list$salmon_version,
-  "Alevin-fry version" = metadata_list$alevinfry_version,
-  "Transcriptome index" = metadata_list$reference_index,
-  "Filtering method" = metadata_list$af_permit_type,
-  "Resolution" = metadata_list$af_resolution, 
+  "Salmon version" = unfiltered_meta$salmon_version,
+  "Alevin-fry version" = unfiltered_meta$alevinfry_version,
+  "Transcriptome index" = unfiltered_meta$reference_index,
+  "Filtering method" = unfiltered_meta$af_permit_type,
+  "Resolution" = unfiltered_meta$af_resolution, 
   "Transcripts included" = dplyr::case_when(
-      metadata_list$transcript_type == "spliced" ~ "Spliced only",
-      metadata_list$transcript_type == "unspliced" ~ "Spliced and unspliced" )
+      unfiltered_meta$transcript_type == "spliced" ~ "Spliced only",
+      unfiltered_meta$transcript_type == "unspliced" ~ "Spliced and unspliced" )
   ) %>%
   t()
 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -2,6 +2,7 @@
 params:
   sample: Example
   sce: !r SingleCellExperiment::SingleCellExperiment()
+  filtered_sce: NULL
   date: !r Sys.Date()
 
 title: "`r glue::glue('ScPCA QC report for {params$sample}')`"

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -14,20 +14,32 @@ output:
     toc_depth: 2
     toc_float: true
     number_sections: true
+    code_folding: hide
 ---
 
-# Introduction
 ```{r setup, message=FALSE}
 library(SingleCellExperiment)
+
+# save some typing later
+sample <- params$sample
+sce <- params$sce
+filtered_sce <- params$filtered_sce
+
+has_filtered <- !is.null(filtered_sce)
 ```
 
-# Processing Information for `r params$sample`
+# Introduction
+
+# Processing Information for `r sample`
 
 ## Sample Metrics
 
-```{r echo=FALSE}
+```{r }
+# extract sce metadata containing processing information as table
+metadata_list <- metadata(sce) 
+
 sample_information <- tibble::tibble(
-  "Sample id" = params$sample,
+  "Sample id" = sample,
   "Tech version" = metadata_list$tech_version,
   "Number of reads sequenced" = format(metadata_list$total_reads, big.mark = ',', scientific = FALSE),
   "Number of mapped reads" = format(metadata_list$mapped_reads, big.mark = ',', scientific = FALSE),
@@ -41,10 +53,7 @@ knitr::kable(sample_information, "simple")
 
 ## Pre-Processing
 
-```{r echo=FALSE}
-# extract sce metadata containing processing information as table
-metadata_list <- metadata(params$sce) 
-
+```{r }
 processing_info <- tibble::tibble(
   "Salmon version" = metadata_list$salmon_version,
   "Alevin-fry version" = metadata_list$alevinfry_version,
@@ -62,9 +71,13 @@ processing_info <- tibble::tibble(
 knitr::kable(processing_info, "simple")
 ```
 
-# `r params$sample` Experiment Summary 
+# `r sample` Experiment Summary 
 
-This sample has `r ncol(params$sce)` cells, assayed for `r nrow(params$sce)` genes.
+This sample has `r ncol(sce)` cells, assayed for `r nrow(sce)` genes.
+
+```{asis, echo = has_filtered}
+After filtering, there are `r ncol(filtered_sce)` cells.
+```
 
 # Session Info
 ```{r session_info}

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -96,9 +96,35 @@ knitr::kable(processing_info, "simple")
 
 This sample has `r ncol(sce)` cells, assayed for `r nrow(sce)` genes.
 
-```{asis, echo = has_filtered}
-After filtering, there are `r ncol(filtered_sce)` cells.
+```{r, results = 'asis'}
+if(has_filtered){
+  cat("After filtering, there are", ncol(filtered_sce), "cells.")
+}
 ```
+
+## Knee plot
+```{r}
+unfiltered_celldata <- data.frame(colData(unfiltered_sce)) %>%
+  mutate(
+    rank = rank(- unfiltered_sce$sum), # using full spec for clarity 
+    filter_status = factor(ifelse(colnames(unfiltered_sce) %in% colnames(filtered_sce),
+                                  "Passed", "Excluded"),
+                           levels = c("Passed", "Excluded"))
+  )
+
+ggplot(unfiltered_celldata, aes(x = rank, y = sum, color = filter_status))+
+  geom_point(aes(shape = filter_status)) +
+  scale_y_log10() + 
+  scale_color_manual(values = c("navyblue", "grey")) + 
+  scale_shape_manual(values = c(16, 1)) + # filled and unfilled circles
+  labs(
+    x = "Rank", 
+    y = "UMI count",
+    color = "Filter status",
+    shape = "Filter status"
+  ) 
+```
+
 
 # Session Info
 ```{r session_info}

--- a/man/generate_qc_report.Rd
+++ b/man/generate_qc_report.Rd
@@ -4,12 +4,14 @@
 \alias{generate_qc_report}
 \title{Generate a QC report from a SingleCellExperiment object}
 \usage{
-generate_qc_report(sce, sample_name, output = NULL)
+generate_qc_report(sce, sample_name, filtered_sce = NULL, output = NULL)
 }
 \arguments{
 \item{sce}{A SingleCellExperiment object that the report will describe}
 
 \item{sample_name}{The name of the sample}
+
+\item{filtered_sce}{An optional filtered single cell experiment derived from first}
 
 \item{output}{The output file path that will be created.
 If the file name does not include an extension, ".html" will be added automatically.


### PR DESCRIPTION
Closes #44 

This PR updates the function for generating a QC report to (optionally) take two SCE objects, and makes a report from those two objects.

The report itself is still mostly a proof of concept, but a few of things are worth noting. 
- The assumption in the report is that there will be two SCE objects passed in with one a subset of the other (this is checked in the outer function). If there is only a single SCE object we will use a copy of the `unfiltered_sce` for the `filtered_sce` as well. Currently that copying happens in the `Rmd` processing, which is more due to happenstance than a conscious decision.
- I added a knee plot, because it seemed a reasonable way to test/demonstrate how the two SCEs might be used.
- There is also a section where I demonstrate one way of having text conditional on the presence or absence of a filtered SCE. Doing this too much will probably get to be a pain, so maybe we should assume the presence of both and just output the results, even when it makes less sense (i.e. the filtered and unfiltered numbers are the same).  I like having this as a demo for now though... We will likely have to do similar things when there is or is not `CITE-seq` data, for example.
