### PR TITLE
Add option for `mtx_format` to import_quant_data

### DIFF
--- a/R/import_quant_data.R
+++ b/R/import_quant_data.R
@@ -4,6 +4,8 @@
 #'
 #' @param quant_dir Path to directory where output files are located.
 #' @param tool Type of tool used to create files (alevin, alevin-fry, cellranger, or kallisto).
+#' @param mtx_format Logical indicating if input data is in matrix market format.
+#'   Default is FALSE.
 #' @param intron_mode Logical indicating if the files included alignment to intronic regions.
 #'   Default is FALSE.
 #' @param usa_mode Logical indicating if Alevin-fry was used, if the USA mode was invoked.
@@ -56,6 +58,7 @@
 import_quant_data <- function(quant_dir,
                               tool = c("cellranger", "alevin", "alevin-fry", "kallisto"),
                               which_counts = c("spliced", "unspliced"),
+                              mtx_format = FALSE,
                               intron_mode = FALSE,
                               usa_mode = FALSE,
                               filter = FALSE,
@@ -78,6 +81,9 @@ import_quant_data <- function(quant_dir,
   }
   if(!is.logical(filter)){
     stop("filter must be set as TRUE or FALSE")
+  }
+  if(!is.logical(mtx_format)){
+    stop("mtx_format must be set as TRUE or FALSE")
   }
 
   # check that usa_mode and intron_mode are used with the proper tools
@@ -105,7 +111,7 @@ import_quant_data <- function(quant_dir,
   }
 
   if (tool %in% c("alevin-fry", "alevin")){
-    sce <- read_alevin(quant_dir, intron_mode, usa_mode, which_counts, tech_version)
+    sce <- read_alevin(quant_dir, mtx_format, intron_mode, usa_mode, which_counts, tech_version)
   } else if (tool == "kallisto") {
     sce <- read_kallisto(quant_dir, intron_mode, which_counts)
   } else if (tool == "cellranger") {

--- a/man/import_quant_data.Rd
+++ b/man/import_quant_data.Rd
@@ -8,6 +8,7 @@ import_quant_data(
   quant_dir,
   tool = c("cellranger", "alevin", "alevin-fry", "kallisto"),
   which_counts = c("spliced", "unspliced"),
+  mtx_format = FALSE,
   intron_mode = FALSE,
   usa_mode = FALSE,
   filter = FALSE,
@@ -24,6 +25,9 @@ import_quant_data(
 \item{which_counts}{If intron_mode is TRUE, which type of counts should be included,
 only counts aligned to spliced cDNA ("spliced") or all spliced and unspliced cDNA ("unspliced").
 Default is "spliced".}
+
+\item{mtx_format}{Logical indicating if input data is in matrix market format.
+Default is FALSE.}
 
 \item{intron_mode}{Logical indicating if the files included alignment to intronic regions.
 Default is FALSE.}


### PR DESCRIPTION
When working on the benchmarking for the 5' samples, I noticed an error in the `import_quant_data` function that the benchmarking functions currently use. I was getting errors when trying to run it and noticed that when the `mtx_format` option was added into `read_alevin` it was never incorporated into the `import_quant_data` function which directly uses `read_alevin`. Here, I am adding in that option so that you can now use `import_quant_data` again to read in alevin-fry data. 