### PR TITLE
Fix Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,8 +7,9 @@ COPY scripts/install_scpca_deps.sh .
 RUN bash ./install_scpca_deps.sh
 
 ##########################
-# Install scpcaTools package
-RUN Rscript -e "remotes::install_github('AlexsLemonade/scpcaTools')"
+# Install scpcaTools package (& test loading)
+RUN Rscript -e "remotes::install_github('AlexsLemonade/scpcaTools'); \
+  require(scpcaTools)"
 
 # set final workdir for commands
 WORKDIR /home

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:4.0.5
+FROM rocker/r-ver:4.1.0
 LABEL maintainer="ccdl@alexslemonade.org"
 LABEL org.opencontainers.image.source https://github.com/AlexsLemonade/scpcaTools
 

--- a/docker/scripts/install_scpca_deps.sh
+++ b/docker/scripts/install_scpca_deps.sh
@@ -29,6 +29,13 @@ apt-get -y --no-install-recommends install \
 
 #### R packages
 ###############
+
+# Set CRAN mirror to allow access to more recent matrixStats
+CRAN="https://packagemanager.rstudio.com/cran/__linux__/focal/2021-08-27"
+echo "options(repos = c(CRAN = '${CRAN}'), download.file.method = 'libcurl')" >> ${R_HOME}/etc/Rprofile.site
+# update all to that repo
+Rscript -e "update.packages(ask = FALSE)"
+
 # this comes first since bioconductor packages are
 # dependent on updated matrixStats
 install2.r --error --skipinstalled -n $NCPUS \

--- a/docker/scripts/install_scpca_deps.sh
+++ b/docker/scripts/install_scpca_deps.sh
@@ -41,12 +41,13 @@ install2.r --error --skipinstalled -n $NCPUS \
     rmarkdown \
     rprojroot \
     RSQLite \
-    tidyverse \
+    tidyverse 
 
 
 ##########################
 # Install bioconductor packages
-Rscript -e "BiocManager::install(c( \
+Rscript -e "withCallingHandlers(
+  BiocManager::install(c( \
     'AnnotationHub', \
     'Biostrings', \
     'bluster', \
@@ -62,7 +63,8 @@ Rscript -e "BiocManager::install(c( \
     'SingleCellExperiment', \
     'SummarizedExperiment', \
     'tximport'), \
-    update = FALSE)"
+    update = FALSE), \
+  warning = function(w) stop(w))" 
 
 rm -rf /tmp/downloaded_packages
 rm -rf /tmp/Rtmp*


### PR DESCRIPTION
Closes #47

With the addition of `miQC`, we needed to update to Bioconductor 3.13. Unfortunately, that broke a few things in the docker build. Worse, it broke them silently.

This PR fixes the failure by updating the base R image to 4.1.0, which updates Bioconductor to 3.13. Unfortunately, this also means that `MatrixGenerics`  has been updated (post release!), and now requires a version of `matrixStats` that came out _after_ R4.1.1 (which froze the R repo). So now I added a repo frozen to a later date.

The real solution here may be to use Renv, but I wanted a quick solution, and this did the job.

To prevent this from causing trouble in the future, I also added a few checks that should cause the docker build to fail if packages fail to install. I think it is fine to have such failures only after PRs are merged (i.e. not check docker build with every PR) as the result of a failure will just be not pushing the failing build to the package repo, which seems fine to me. We might add a badge or something to indicate that the docker image may not be up to date, but I don't think it is a terrible failure mode.