### PR TITLE
Fix references to sce in QC function

### DIFF
--- a/R/generate_qc_report.R
+++ b/R/generate_qc_report.R
@@ -20,19 +20,19 @@ generate_qc_report <- function(sample_name,
                                unfiltered_sce,
                                filtered_sce = NULL,
                                output = NULL){
-  if(!inherits(sce, "SingleCellExperiment")){
-    stop("`sce` must be a SingleCellExperiment object.")
+  if(!inherits(unfiltered_sce, "SingleCellExperiment")){
+    stop("`unfiltered_sce` must be a SingleCellExperiment object.")
   }
   # check that the filtered sce is as expected
   if(!is.null(filtered_sce)){
     if (!inherits(filtered_sce, "SingleCellExperiment")){
       stop("`filtered_sce` must be a SingleCellExperiment object.")
     }
-    if (ncol(sce) < ncol(filtered_sce)){
-      stop("`filtered_sce` should have fewer cells than `sce`")
+    if (ncol(unfiltered_sce) < ncol(filtered_sce)){
+      stop("`filtered_sce` should have fewer cells than `unfiltered_sce`")
     }
-    if (!all(colnames(filtered_sce) %in% colnames(sce))){
-      "Some cells in `filtered_sce` are not present in `sce`, from which it should be derived."
+    if (!all(colnames(filtered_sce) %in% colnames(unfiltered_sce))){
+      "Some cells in `filtered_sce` are not present in `unfiltered_sce`, from which it should be derived."
     }
   }
 
@@ -51,7 +51,7 @@ generate_qc_report <- function(sample_name,
     output_dir = output_dir,
     params = list(
       sample = sample_name,
-      unfiltered_sce = sce,
+      unfiltered_sce = unfiltered_sce,
       filtered_sce = filtered_sce
     ),
     envir = new.env()

--- a/man/generate_qc_report.Rd
+++ b/man/generate_qc_report.Rd
@@ -4,12 +4,17 @@
 \alias{generate_qc_report}
 \title{Generate a QC report from a SingleCellExperiment object}
 \usage{
-generate_qc_report(sce, sample_name, filtered_sce = NULL, output = NULL)
+generate_qc_report(
+  sample_name,
+  unfiltered_sce,
+  filtered_sce = NULL,
+  output = NULL
+)
 }
 \arguments{
-\item{sce}{A SingleCellExperiment object that the report will describe}
+\item{sample_name}{The name of the sample for report headers}
 
-\item{sample_name}{The name of the sample}
+\item{unfiltered_sce}{A SingleCellExperiment object that the report will describe}
 
 \item{filtered_sce}{An optional filtered single cell experiment derived from first}
 
@@ -25,7 +30,7 @@ Generate a QC report from a SingleCellExperiment object
 }
 \examples{
 \dontrun{
-generate_qc_report(my_sce, "Sample 1", output = "reports/sample1_report.html")
+generate_qc_report("Sample 1", my_sce, output = "reports/sample1_report.html")
 }
 
 }


### PR DESCRIPTION
I thought I had fixed the references to `sce` in the QC report function, but apparently I missed some. 

This also updates docs to match, which didn't happen for whatever reason.