### PR TITLE
Add pandoc to docker

### DIFF
--- a/docker/scripts/install_scpca_deps.sh
+++ b/docker/scripts/install_scpca_deps.sh
@@ -25,6 +25,7 @@ apt-get -y --no-install-recommends install \
     libudunits2-dev \
     libxml2-dev \
     libxtst6 \
+    pandoc \
   && rm -rf /var/lib/apt/lists/*
 
 #### R packages


### PR DESCRIPTION
To actually run the QC reports within the docker container, we need `pandoc`, so here I am adding it! I verified that this is sufficent to allow html files to knit. If we later want to make pdfs, we may need to add some of the suggested tex packages, but I don't think that is in our plans. 