### PR TITLE
Add testing to qc report

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,6 +20,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: r-lib/actions/setup-r@v1
+      - name: Install pandoc
+        run: |
+          apt-get update && apt-get -y --no-install-recommends install pandoc
       - name: Install dependencies
         run: |
           options(repos = c(CRAN = "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"))

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,7 +22,8 @@ jobs:
       - uses: r-lib/actions/setup-r@v1
       - name: Install pandoc
         run: |
-          apt-get update && apt-get -y --no-install-recommends install pandoc
+          sudo apt-get update
+          sudo apt-get -y --no-install-recommends install pandoc
       - name: Install dependencies
         run: |
           options(repos = c(CRAN = "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"))

--- a/R/generate_qc_report.R
+++ b/R/generate_qc_report.R
@@ -45,7 +45,7 @@ generate_qc_report <- function(sample_name,
   }
 
   rmd <- system.file(file.path("rmd", "qc_report.rmd"), package = "scpcaTools")
-  rmarkdown::render(
+  suppressPackageStartupMessages(rmarkdown::render(
     rmd,
     output_file = output_file,
     output_dir = output_dir,
@@ -54,6 +54,7 @@ generate_qc_report <- function(sample_name,
       unfiltered_sce = unfiltered_sce,
       filtered_sce = filtered_sce
     ),
-    envir = new.env()
-  )
+    envir = new.env(),
+    quiet = TRUE
+  ))
 }

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -94,7 +94,7 @@ knitr::kable(processing_info, "simple")
 
 # `r sample` Experiment Summary 
 
-This sample has `r ncol(sce)` cells, assayed for `r nrow(sce)` genes.
+This sample has `r ncol(unfiltered_sce)` cells, assayed for `r nrow(unfiltered_sce)` genes.
 
 ```{r, results = 'asis'}
 if(has_filtered){

--- a/tests/testthat/test-generate_qc_report.R
+++ b/tests/testthat/test-generate_qc_report.R
@@ -7,4 +7,6 @@ test_that("generating a qc report works", {
                                 unfiltered_sce = sce,
                                 filtered_sce = filt_sce, )
   expect_true(file.exists(qc_file))
+  # clean up
+  file.remove(qc_file)
 })

--- a/tests/testthat/test-generate_qc_report.R
+++ b/tests/testthat/test-generate_qc_report.R
@@ -1,0 +1,10 @@
+set.seed(1665)
+sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 0)
+filt_sce <- sce[,1:50]
+
+test_that("generating a qc report works", {
+  qc_file <- generate_qc_report(sample_name = "TEST",
+                                unfiltered_sce = sce,
+                                filtered_sce = filt_sce, )
+  expect_true(file.exists(qc_file))
+})


### PR DESCRIPTION
After yet another little bug that my ad-hoc testing missed, this PR adds minimal tests to the qc_report generation script (and fixes the bug).

The test is pretty minimal, but it does clean up after itself!
I also made the qc rendering quieter, because it was bugging me.

