### PR TITLE
Add plots to QC report

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,6 +26,7 @@ Imports:
     ggplot2,
     glue,
     jsonlite,
+    kableExtra,
     magrittr,
     Matrix,
     Matrix.utils,

--- a/docker/scripts/install_scpca_deps.sh
+++ b/docker/scripts/install_scpca_deps.sh
@@ -44,6 +44,7 @@ install2.r --error --skipinstalled -n $NCPUS \
     DBI \
     devtools \
     here \
+    kableExtra \
     matrixStats \
     optparse \
     rmarkdown \

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -13,7 +13,7 @@ output:
     toc: true
     toc_depth: 2
     toc_float: true
-    number_sections: true
+    number_sections: false
     code_download: true
 ---
 
@@ -27,13 +27,13 @@ library(SingleCellExperiment)
 library(dplyr)
 library(ggplot2)
 
-# Set standard ggplot theme
+# Set default ggplot theme
 theme_set(theme_bw())
 ```
 
 ```{r sce_setup}
 # save some typing later
-sample <- params$sample
+sample_id <- params$sample
 unfiltered_sce <- params$unfiltered_sce
 filtered_sce <- params$filtered_sce
 
@@ -51,7 +51,7 @@ if (is.null(unfiltered_sce$sum)){
 
 # Introduction
 
-# Processing Information for `r sample`
+# Processing Information for `r sample_id`
 
 ## Raw Sample Metrics
 
@@ -60,39 +60,45 @@ if (is.null(unfiltered_sce$sum)){
 unfiltered_meta <- metadata(unfiltered_sce) 
 
 sample_information <- tibble::tibble(
-  "Sample id" = sample,
-  "Tech version" = unfiltered_meta$tech_version,
+  "Sample id" = sample_id,
+  "Tech version" = format(unfiltered_meta$tech_version),
   "Number of reads sequenced" = format(unfiltered_meta$total_reads, big.mark = ',', scientific = FALSE),
   "Number of mapped reads" = format(unfiltered_meta$mapped_reads, big.mark = ',', scientific = FALSE),
   "Number of cells reported by alevin-fry" = format(unfiltered_meta$af_num_cells, big.mark = ',', scientific = FALSE)
 ) %>%
+  mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) %>%
   t()
 
 # make table with sample information
-knitr::kable(sample_information, "simple")
+knitr::kable(sample_information,
+             caption = "Sample Information") %>%
+  kableExtra::kable_styling(bootstrap_options = "striped")
 ```
 
 ## Pre-Processing Information
 
 ```{r }
 processing_info <- tibble::tibble(
-  "Salmon version" = unfiltered_meta$salmon_version,
-  "Alevin-fry version" = unfiltered_meta$alevinfry_version,
-  "Transcriptome index" = unfiltered_meta$reference_index,
-  "Filtering method" = unfiltered_meta$af_permit_type,
-  "Resolution" = unfiltered_meta$af_resolution, 
+  "Salmon version"       = format(unfiltered_meta$salmon_version),
+  "Alevin-fry version"   = format(unfiltered_meta$alevinfry_version),
+  "Transcriptome index"  = format(unfiltered_meta$reference_index),
+  "Filtering method"     = format(unfiltered_meta$af_permit_type),
+  "Resolution"           = format(unfiltered_meta$af_resolution), 
   "Transcripts included" = dplyr::case_when(
-      unfiltered_meta$transcript_type == "spliced" ~ "Spliced only",
-      unfiltered_meta$transcript_type == "unspliced" ~ "Spliced and unspliced" )
+      format(unfiltered_meta$transcript_type) == "spliced" ~ "Spliced only",
+      format(unfiltered_meta$transcript_type) == "unspliced" ~ "Spliced and unspliced",
+      TRUE ~ format(unfiltered_meta$transcript_type))
   ) %>%
+  mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) %>%
   t()
 
 
 # make table with processing information
-knitr::kable(processing_info, "simple")
+knitr::kable(processing_info, caption ="Processing information") %>%
+  kableExtra::kable_styling(bootstrap_options = "striped")
 ```
 
-# `r sample` Experiment Summary 
+# `r sample_id` Experiment Summary 
 
 This sample has `r ncol(unfiltered_sce)` cells, assayed for `r nrow(unfiltered_sce)` genes.
 
@@ -114,7 +120,8 @@ unfiltered_celldata <- data.frame(colData(unfiltered_sce)) %>%
 
 ggplot(unfiltered_celldata, aes(x = rank, y = sum, color = filter_status))+
   geom_point(aes(shape = filter_status)) +
-  scale_y_log10() + 
+  scale_y_log10() +
+  scale_x_log10() + 
   scale_color_manual(values = c("navyblue", "grey")) + 
   scale_shape_manual(values = c(16, 1)) + # filled and unfilled circles
   labs(
@@ -127,8 +134,10 @@ ggplot(unfiltered_celldata, aes(x = rank, y = sum, color = filter_status))+
 
 
 # Session Info
+<details>
+<summary>R session information</summary>
 ```{r session_info}
 sessioninfo::session_info()
 ```
-
+</details>
 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -46,6 +46,11 @@ if (!has_filtered){
 # add cell stats if missing
 if (is.null(unfiltered_sce$sum)){
   unfiltered_sce <- scuttle::addPerCellQCMetrics(unfiltered_sce)
+  unfiltered_sce$subsets_mito_percent <- NA_real_
+}
+if (is.null(filtered_sce$sum)){
+  filtered_sce <- scuttle::addPerCellQCMetrics(filtered_sce)
+  filtered_sce$subsets_mito_percent <- NA_real_
 }
 ```
 
@@ -61,12 +66,12 @@ unfiltered_meta <- metadata(unfiltered_sce)
 
 sample_information <- tibble::tibble(
   "Sample id" = sample_id,
-  "Tech version" = format(unfiltered_meta$tech_version),
+  "Tech version" = format(unfiltered_meta$tech_version), # format to keep nulls
   "Number of reads sequenced" = format(unfiltered_meta$total_reads, big.mark = ',', scientific = FALSE),
   "Number of mapped reads" = format(unfiltered_meta$mapped_reads, big.mark = ',', scientific = FALSE),
   "Number of cells reported by alevin-fry" = format(unfiltered_meta$af_num_cells, big.mark = ',', scientific = FALSE)
 ) %>%
-  mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) %>%
+  mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) %>% # reformat nulls
   t()
 
 # make table with sample information
@@ -109,7 +114,7 @@ if(has_filtered){
 ```
 
 ## Knee plot
-```{r}
+```{r, fig.cap="Knee plot of filtered and unfiltered droplets"}
 unfiltered_celldata <- data.frame(colData(unfiltered_sce)) %>%
   mutate(
     rank = rank(- unfiltered_sce$sum), # using full spec for clarity 
@@ -129,7 +134,32 @@ ggplot(unfiltered_celldata, aes(x = rank, y = sum, color = filter_status))+
     y = "UMI count",
     color = "Filter status",
     shape = "Filter status"
-  ) 
+  ) + 
+  theme(legend.position = c(0, 0),
+        legend.justification = c(0,0),
+        legend.background = element_rect(color = "grey20", size = 0.25),
+        legend.box.margin = margin(rep(5, 4)))
+```
+
+
+## UMI-gene count plot
+
+```{r, fig.cap="Total UMI x genes expressed"}
+filtered_celldata <- data.frame(colData(filtered_sce)) 
+
+ggplot(filtered_celldata, 
+       aes (x = sum,
+            y = detected, 
+            color = subsets_mito_percent)) +
+  geom_point(alpha = 0.3) +
+  scale_color_viridis_c(limits = c(0, 100)) + 
+  labs(x = "Total UMI Count",
+       y = "Number of Genes Expressed",
+       color = "Mitochondrial\nPercent") + 
+  theme(legend.position = c(0, 1),
+        legend.justification = c(0,1),
+        legend.background = element_rect(color = "grey20", size = 0.25),
+        legend.box.margin = margin(rep(5, 4)))
 ```
 
 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -120,17 +120,19 @@ if(has_filtered){
 ```{r, fig.cap="Knee plot of filtered and unfiltered droplets"}
 unfiltered_celldata <- data.frame(colData(unfiltered_sce)) %>%
   mutate(
-    rank = rank(- unfiltered_sce$sum), # using full spec for clarity 
+    rank = rank(- unfiltered_sce$sum, ties.method = "first"), # using full spec for clarity 
     filter_status = factor(ifelse(colnames(unfiltered_sce) %in% colnames(filtered_sce),
                                   "Passed", "Excluded"),
                            levels = c("Passed", "Excluded"))
-  )
+  ) %>%
+  filter(sum > 0) %>% # remove zeros for plotting
+  arrange(desc(rank))
 
 ggplot(unfiltered_celldata, aes(x = rank, y = sum, color = filter_status))+
-  geom_point(aes(shape = filter_status)) +
+  geom_point(aes(shape = filter_status),alpha = 0.2, size = 2) +
   scale_y_log10() +
   scale_x_log10() + 
-  scale_color_manual(values = c("navyblue", "grey")) + 
+  scale_color_manual(values = c("navyblue", "grey40")) + 
   scale_shape_manual(values = c(16, 1)) + # filled and unfilled circles
   labs(
     x = "Rank", 
@@ -138,6 +140,7 @@ ggplot(unfiltered_celldata, aes(x = rank, y = sum, color = filter_status))+
     color = "Filter status",
     shape = "Filter status"
   ) + 
+  guides(color = guide_legend(override.aes = list(alpha = 1))) + 
   theme(legend.position = c(0, 0),
         legend.justification = c(0,0),
         legend.background = element_rect(color = "grey20", size = 0.25),
@@ -145,7 +148,7 @@ ggplot(unfiltered_celldata, aes(x = rank, y = sum, color = filter_status))+
 ```
 
 
-## UMI-gene count plot
+## UMI - expressed gene count plot
 
 ```{r, fig.cap="Total UMI x genes expressed"}
 filtered_celldata <- data.frame(colData(filtered_sce)) 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -75,9 +75,10 @@ sample_information <- tibble::tibble(
   t()
 
 # make table with sample information
-knitr::kable(sample_information,
-             caption = "Sample Information") %>%
-  kableExtra::kable_styling(bootstrap_options = "striped")
+knitr::kable(sample_information) %>%
+  kableExtra::kable_styling(bootstrap_options = "striped",
+                            full_width = FALSE,
+                            position = "left")
 ```
 
 ## Pre-Processing Information
@@ -99,8 +100,10 @@ processing_info <- tibble::tibble(
 
 
 # make table with processing information
-knitr::kable(processing_info, caption ="Processing information") %>%
-  kableExtra::kable_styling(bootstrap_options = "striped")
+knitr::kable(processing_info) %>%
+  kableExtra::kable_styling(bootstrap_options = "striped",
+                            full_width = FALSE,
+                            position = "left")
 ```
 
 # `r sample_id` Experiment Summary 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -46,7 +46,6 @@ if (!has_filtered){
 # add cell stats if missing
 if (is.null(unfiltered_sce$sum)){
   unfiltered_sce <- scuttle::addPerCellQCMetrics(unfiltered_sce)
-  unfiltered_sce$subsets_mito_percent <- NA_real_
 }
 if (is.null(filtered_sce$sum)){
   filtered_sce <- scuttle::addPerCellQCMetrics(filtered_sce)

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -186,7 +186,7 @@ if(skip_miQC){
   filtered_sce$prob_compromised <- NULL
   miQC::plotModel(filtered_sce, model = metadata(filtered_sce)$miQC_model) + 
     coord_cartesian(ylim = c(0,100)) +
-    labs(x = "Number of genes expressed",
+    labs(x = "Number of genes detected",
          y = "Percent reads mitochondrial") +
     theme(plot.margin = margin(rep(20, 4)),
           legend.position = c(1, 1),

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -123,7 +123,7 @@ if(has_filtered){
 ```
 
 ## Knee plot
-```{r, fig.cap="Knee plot of filtered and unfiltered droplets"}
+```{r, fig.alt="Knee plot of filtered and unfiltered droplets"}
 unfiltered_celldata <- data.frame(colData(unfiltered_sce)) %>%
   mutate(
     rank = rank(- unfiltered_sce$sum, ties.method = "first"), # using full spec for clarity 
@@ -136,27 +136,28 @@ unfiltered_celldata <- data.frame(colData(unfiltered_sce)) %>%
 
 ggplot(unfiltered_celldata, aes(x = rank, y = sum, color = filter_status))+
   geom_point(aes(shape = filter_status),alpha = 0.2, size = 2) +
-  scale_y_log10() +
-  scale_x_log10() + 
-  scale_color_manual(values = c("navyblue", "grey40")) + 
+  scale_x_log10(labels = scales::label_number()) +
+  scale_y_log10(labels = scales::label_number()) + 
+  scale_color_manual(values = c("darkgreen", "grey80")) + 
   scale_shape_manual(values = c(16, 1)) + # filled and unfilled circles
   labs(
     x = "Rank", 
-    y = "UMI count",
+    y = "Total UMI count",
     color = "Filter status",
     shape = "Filter status"
   ) + 
   guides(color = guide_legend(override.aes = list(alpha = 1))) + 
-  theme(legend.position = c(0, 0),
+  theme(plot.margin = margin(rep(20, 4)),
+        legend.position = c(0, 0),
         legend.justification = c(0,0),
         legend.background = element_rect(color = "grey20", size = 0.25),
         legend.box.margin = margin(rep(5, 4)))
 ```
 
 
-## UMI - expressed gene count plot
+## Cell read metrics 
 
-```{r, fig.cap="Total UMI x genes expressed"}
+```{r, fig.alt="Total UMI x genes expressed"}
 filtered_celldata <- data.frame(colData(filtered_sce)) 
 
 ggplot(filtered_celldata, 
@@ -165,10 +166,11 @@ ggplot(filtered_celldata,
             color = subsets_mito_percent)) +
   geom_point(alpha = 0.3) +
   scale_color_viridis_c(limits = c(0, 100)) + 
-  labs(x = "Total UMI Count",
-       y = "Number of Genes Expressed",
-       color = "Mitochondrial\nPercent") + 
-  theme(legend.position = c(0, 1),
+  labs(x = "Total UMI count",
+       y = "Number of genes detected",
+       color = "Percent reads\nmitochondrial") + 
+  theme(plot.margin = margin(rep(20, 4)),
+        legend.position = c(0, 1),
         legend.justification = c(0,1),
         legend.background = element_rect(color = "grey20", size = 0.25),
         legend.box.margin = margin(rep(5, 4)))
@@ -176,17 +178,21 @@ ggplot(filtered_celldata,
 
 ## miQC model diagnostics
 
-```{r, fig.cap="miQC model diagnostics plot", results='asis', warning=FALSE}
+```{r, fig.alt="miQC model diagnostics plot", results='asis', warning=FALSE}
 if(skip_miQC){
   cat("miQC model not created, skipping miQC plot. Usually this is because mitochondrial gene data was not available.")
 }else{
   # remove prob_compromised if it exists, as this will cause errors with plotModel
   filtered_sce$prob_compromised <- NULL
   miQC::plotModel(filtered_sce, model = metadata(filtered_sce)$miQC_model) + 
-    theme(legend.position = c(1, 1),
-      legend.justification = c(1,1),
-      legend.background = element_rect(color = "grey20", size = 0.25),
-      legend.box.margin = margin(rep(5, 4)))
+    coord_cartesian(ylim = c(0,100)) +
+    labs(x = "Number of genes expressed",
+         y = "Percent reads mitochondrial") +
+    theme(plot.margin = margin(rep(20, 4)),
+          legend.position = c(1, 1),
+          legend.justification = c(1,1),
+          legend.background = element_rect(color = "grey20", size = 0.25),
+          legend.box.margin = margin(rep(5, 4)))
 }
 ```
 


### PR DESCRIPTION
Here I am mostly adding the Total vs. gene count plot to the QC report. I also fixed the knee plot and made the session info hidden by default, so closing all three of those issues here.

I was also playing around with #54, which I ended up abandoning, but in that process I added a bit of formatting to the tables, including making them not full-width, and striping the rows.

A few things to focus on that I was thinking about as I did them: 
- Please also look at all axis labels and legend titles! (Should I make the knee plot use non-scientific notation?)

- For consistency among reports, I made the mitochondrial percentage go from 0-100% for all reports. This may make lower numbers harder to see in mostly-good plots (where no cells are above 50%, say). I thought the consistency was more important, but we could tweak the color scale if we think it matters.

- The other potentially controversial aesthetic decision I made was to move the figure legends into the figure panels, at least for the knee & UMI/gene plots. In both of these plots, the location of the data is predictable, so in the vast majority of cases the positions I chose will not overlap data. Still, there is a chance they will, so if there is worry, I can move them back out.  (when we add the miQC plot, the top right ought to work as a clear space)

I am attaching an [example report](https://github.com/AlexsLemonade/scpcaTools/files/7262155/SCPCL000001_qc.html.zip) (zipped, b/c github), and the two main figures I worked on below, for reference:
![image](https://user-images.githubusercontent.com/20483/135521936-6079587d-d297-4891-b234-e4a9923f4b8b.png)
![image](https://user-images.githubusercontent.com/20483/135521948-3a975d48-1895-4722-8f86-1019ab1453a6.png)


closes #39
closes #40
closes #19
closes #55