### PR TITLE
Add table with basic cell statistics to QC report

### DIFF
--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -12,8 +12,7 @@ output:
   html_document:
     toc: true
     toc_depth: 2
-    toc_float: 
-      collapsed: false
+    toc_float: true
     number_sections: false
     code_download: true
 ---

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -120,21 +120,21 @@ if(has_filtered){
 }
 ```
 
-## Basic Cell Statistics 
+## Cell Statistics 
 
 ```{r}
 basic_statistics <- tibble::tibble(
   "Number of cells post filtering"              = format(ncol(filtered_sce), big.mark = ","),
   "Median UMI count per cell"                   = format(median(filtered_sce$sum), big.mark = ","),
   "Median genes detected per cell"              = format(median(filtered_sce$detected), big.mark = ","),
-  "Median percent reads mitochondrial per cell" = paste0(round(median(filtered_sce$subsets_mito_percent), 2), " %")
+  "Median percent reads mitochondrial per cell" = paste0(round(median(filtered_sce$subsets_mito_percent), 2), "%")
   ) %>%
   mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) %>%
   t()
 
 
 # make table with basic statistics
-knitr::kable(basic_statistics) %>%
+knitr::kable(basic_statistics, align = "lr") %>%
   kableExtra::kable_styling(bootstrap_options = "striped",
                             full_width = FALSE,
                             position = "left")

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -72,7 +72,7 @@ sample_information <- tibble::tibble(
   "Sample id" = sample_id,
   "Tech version" = format(unfiltered_meta$tech_version), # format to keep nulls
   "Number of reads sequenced" = format(unfiltered_meta$total_reads, big.mark = ',', scientific = FALSE),
-  "Number of mapped reads" = format(unfiltered_meta$mapped_reads, big.mark = ',', scientific = FALSE),
+  "Percent of reads mapped" = paste0(round((unfiltered_meta$mapped_reads/unfiltered_meta$total_reads) *100, 2), "%"),
   "Number of cells reported by alevin-fry" = format(unfiltered_meta$af_num_cells, big.mark = ',', scientific = FALSE)
 ) %>%
   mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) %>% # reformat nulls
@@ -124,10 +124,11 @@ if(has_filtered){
 
 ```{r}
 basic_statistics <- tibble::tibble(
-  "Number of cells post filtering"              = format(ncol(filtered_sce), big.mark = ","),
-  "Median UMI count per cell"                   = format(median(filtered_sce$sum), big.mark = ","),
-  "Median genes detected per cell"              = format(median(filtered_sce$detected), big.mark = ","),
-  "Median percent reads mitochondrial per cell" = paste0(round(median(filtered_sce$subsets_mito_percent), 2), "%")
+  "Number of cells post filtering"     = format(ncol(filtered_sce), big.mark = ","),
+  "Percent of reads in cells"          = paste0(round((sum(filtered_sce$sum)/sum(unfiltered_sce$sum))*100,2),"%"),
+  "Median UMI count per cell"          = format(median(filtered_sce$sum), big.mark = ","),
+  "Median genes detected per cell"     = format(median(filtered_sce$detected), big.mark = ","),
+  "Median percent reads mitochondrial" = paste0(round(median(filtered_sce$subsets_mito_percent), 2), "%")
   ) %>%
   mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) %>%
   t()

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -60,8 +60,6 @@ if (is.null(metadata(filtered_sce)$miQC_model) & !skip_miQC){
 }
 ```
 
-# Introduction
-
 # Processing Information for `r sample_id`
 
 ## Raw Sample Metrics
@@ -122,7 +120,30 @@ if(has_filtered){
 }
 ```
 
-## Knee plot
+## Basic Cell Statistics 
+
+```{r}
+basic_statistics <- tibble::tibble(
+  "Number of cells post filtering"              = format(ncol(filtered_sce), big.mark = ","),
+  "Median UMI count per cell"                   = format(median(filtered_sce$sum), big.mark = ","),
+  "Median genes detected per cell"              = format(median(filtered_sce$detected), big.mark = ","),
+  "Median percent reads mitochondrial per cell" = paste0(round(median(filtered_sce$subsets_mito_percent), 2), " %")
+  ) %>%
+  mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) %>%
+  t()
+
+
+# make table with basic statistics
+knitr::kable(basic_statistics) %>%
+  kableExtra::kable_styling(bootstrap_options = "striped",
+                            full_width = FALSE,
+                            position = "left")
+
+```
+
+
+## Knee Plot
+
 ```{r, fig.alt="Knee plot of filtered and unfiltered droplets"}
 unfiltered_celldata <- data.frame(colData(unfiltered_sce)) %>%
   mutate(
@@ -155,7 +176,7 @@ ggplot(unfiltered_celldata, aes(x = rank, y = sum, color = filter_status))+
 ```
 
 
-## Cell read metrics 
+## Cell Read Metrics 
 
 ```{r, fig.alt="Total UMI x genes expressed"}
 filtered_celldata <- data.frame(colData(filtered_sce)) 
@@ -176,7 +197,7 @@ ggplot(filtered_celldata,
         legend.box.margin = margin(rep(5, 4)))
 ```
 
-## miQC model diagnostics
+## miQC Model Diagnostics
 
 ```{r, fig.alt="miQC model diagnostics plot", results='asis', warning=FALSE}
 if(skip_miQC){

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -12,7 +12,8 @@ output:
   html_document:
     toc: true
     toc_depth: 2
-    toc_float: true
+    toc_float: 
+      collapsed: false
     number_sections: false
     code_download: true
 ---


### PR DESCRIPTION
Closes #18. Based on discussions in both #37 and #18, I have added in a table that includes some basic cell statistics to the qc report. These are statistics that are calculated after filtering using `emptyDrops`, so in addition to including the median UMI/cell, genes detected/ cell and % mito/cell, I also added in the number of cells post filtering at the top of the table. I thought this table fit in best in the `Experiment Summary` section, but before the knee plot. 

A few notes/ questions for the changes implemented here:

- Do we want to include both median and mean? I included median for now but I know Cell Ranger includes both so we could add that in if we think it's necessary. 
- While working on this I noticed that the majority of the section headers were title case other than a few in sentence case, so I chose to convert them all to title case. Let me know if you would prefer it the other way around - I just went with the majority on this one. 
- I also removed the `Introduction` header, since there wasn't anything that seemed to be really underneath it and it seemed out of place, but let me know if there was an intended use there. 
- If there are any other basic statistics on a per cell level that you think we should be including here, happy to discuss putting them in!

I have included a copy of an [example report](https://github.com/AlexsLemonade/scpcaTools/files/7281347/SCPCL000006_example.html.zip) for help in reviewing. 

Here is a screenshot of the table that has been added as well: 
<img width="673" alt="Screen Shot 2021-10-04 at 4 15 44 PM" src="https://user-images.githubusercontent.com/54039191/135925840-91db536e-af0e-441a-a12c-7a7b6fff3666.png">