### PR TITLE
59 Add explanatory captions to QC report plots

### DIFF
--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -218,7 +218,7 @@ ggplot(grouped_celldata, aes(x = med_rank, y = med_sum, color = pct_passed)) +
 ```
 
 The total UMI count of each droplet (barcode) plotted against the rank of that droplet allows visualization of the distribution of sequencing depth across droplets. 
-The droplets that are expected to contain cells were identified with [`DropletUtils::emptyDrops()`](https://bioconductor.org/packages/release/bioc/html/DropletUtils.html) , which uses both the total UMI counts and expressed gene content ([Lun  _et al._ 2019](https://doi.org/10.1186/s13059-019-1662-y)).
+The droplets that are expected to contain cells were identified with [`DropletUtils::emptyDrops()`](https://bioconductor.org/packages/release/bioc/html/DropletUtils.html), which uses both the total UMI counts and expressed gene content ([Lun  _et al._ 2019](https://doi.org/10.1186/s13059-019-1662-y)).
 As the boundary between droplets passing and failing this filter does not correspond only to the axes of this plot, some regions contain droplets in both categories, so we here color the plot by the percentage passing the filter.
 
 ## Cell Read Metrics 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -6,7 +6,7 @@ params:
   date: !r Sys.Date()
 
 title: "`r glue::glue('ScPCA QC report for {params$sample}')`"
-author: "CCDL"
+author: "Childhood Cancer Data Lab"
 date: "`r params$date`"
 output: 
   html_document:

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -149,54 +149,31 @@ knitr::kable(basic_statistics, align = 'r') %>%
 
 ## Knee Plot
 
-```{r, fig.alt="Knee plot of filtered and unfiltered droplets"}
+```{r, fig.alt="Smoothed knee plot of filtered and unfiltered droplets"}
 unfiltered_celldata <- data.frame(colData(unfiltered_sce)) %>%
   mutate(
     rank = rank(- unfiltered_sce$sum, ties.method = "first"), # using full spec for clarity 
-    filter_status = factor(ifelse(colnames(unfiltered_sce) %in% colnames(filtered_sce),
-                                  "Passed", "Excluded"),
-                           levels = c("Passed", "Excluded"))
+    filter_pass = colnames(unfiltered_sce) %in% colnames(filtered_sce)
   ) %>%
-  filter(sum > 0) %>% # remove zeros for plotting
-  arrange(desc(rank))
+  select(sum, rank, filter_pass) %>%
+  filter(sum > 0) # remove zeros for plotting
 
-ggplot(unfiltered_celldata, aes(x = rank, y = sum, color = filter_status))+
-  geom_point(aes(size = filter_status), alpha = 0.2) +
-  scale_x_log10(labels = scales::label_number()) +
-  scale_y_log10(labels = scales::label_number()) + 
-  scale_color_manual(values = c("darkgreen", "grey80")) + 
-  scale_size_manual(values = c(2, 1)) +
-  labs(
-    x = "Rank", 
-    y = "Total UMI count",
-    color = "Filter status",
-    size  = "Filter status"
-  ) + 
-  guides(color = guide_legend(override.aes = list(alpha = 1))) + 
-  theme(legend.position = c(0, 0),
-        legend.justification = c(0,0),
-        legend.background = element_rect(color = "grey20", size = 0.25),
-        legend.box.margin = margin(rep(5, 4)))
-```
 
-```{r, fig.alt="Smoothed knee plot of filtered and unfiltered droplets"}
 grouped_celldata <- unfiltered_celldata %>%
-  select(sum, rank, filter_status) %>%
   mutate(rank_group = floor(rank / 100) )%>%
   group_by(rank_group) %>%
   summarize(
     med_sum = median(sum),
     med_rank = median(rank),
-    pct_passed = sum(filter_status == "Passed") / n() * 100
-  )
+    pct_passed = sum(filter_pass) / n() * 100
+  ) 
 
 top_celldata <- unfiltered_celldata %>%
-  select(sum, rank, filter_status) %>%
   filter(rank <= 50) %>%
-  mutate(filter_status = ifelse(filter_status == "Passed", 100, 0))
+  mutate(filter_pct = ifelse(filter_pass, 100, 0))
 
 ggplot(grouped_celldata, aes(x = med_rank, y = med_sum, color = pct_passed)) + 
-  geom_point(mapping = aes(x = rank, y = sum, color = filter_status),
+  geom_point(mapping = aes(x = rank, y = sum, color = filter_pct),
              data = top_celldata,
              alpha = 0.5) + 
   geom_line(size = 2, lineend = "round", linejoin= "round") +

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -180,6 +180,36 @@ ggplot(unfiltered_celldata, aes(x = rank, y = sum, color = filter_status))+
         legend.box.margin = margin(rep(5, 4)))
 ```
 
+```{r, fig.alt="Smoothed knee plot of filtered and unfiltered droplets"}}
+grouped_celldata <- unfiltered_celldata %>%
+  select(sum, rank, filter_status) %>%
+  mutate(rank_group = floor(rank / 100) )%>%
+  group_by(rank_group) %>%
+  summarize(
+    mean_sum = mean(sum),
+    mean_rank = mean(rank),
+    mean_passed = sum(filter_status == "Passed") / n() * 100
+  )
+
+ggplot(grouped_celldata, aes(x = mean_rank, y = mean_sum, color = mean_passed)) + 
+  geom_line(size = 2, lineend = "round", linejoin= "round") +
+  scale_x_log10(labels = scales::label_number()) +
+  scale_y_log10(labels = scales::label_number(accuracy = 1)) + 
+  scale_color_gradient2(low = "grey70", 
+                        mid = "forestgreen", 
+                        high = "darkgreen", 
+                        midpoint = 50) +
+  labs(
+    x = "Rank", 
+    y = "Total UMI count",
+    color = "% passing\ncell filter"
+  ) + 
+  theme(legend.position = c(0, 0),
+        legend.justification = c(0,0),
+        legend.background = element_rect(color = "grey20", size = 0.25),
+        legend.box.margin = margin(rep(5, 4)))
+```
+
 
 ## Cell Read Metrics 
 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -29,7 +29,8 @@ library(dplyr)
 library(ggplot2)
 
 # Set default ggplot theme
-theme_set(theme_bw())
+theme_set(theme_bw() + 
+          theme(plot.margin = margin(rep(20, 4))))
 ```
 
 ```{r sce_setup}
@@ -172,8 +173,7 @@ ggplot(unfiltered_celldata, aes(x = rank, y = sum, color = filter_status))+
     shape = "Filter status"
   ) + 
   guides(color = guide_legend(override.aes = list(alpha = 1))) + 
-  theme(plot.margin = margin(rep(20, 4)),
-        legend.position = c(0, 0),
+  theme(legend.position = c(0, 0),
         legend.justification = c(0,0),
         legend.background = element_rect(color = "grey20", size = 0.25),
         legend.box.margin = margin(rep(5, 4)))
@@ -235,8 +235,7 @@ ggplot(filtered_celldata,
   labs(x = "Total UMI count",
        y = "Number of genes detected",
        color = "Percent reads\nmitochondrial") + 
-  theme(plot.margin = margin(rep(20, 4)),
-        legend.position = c(0, 1),
+  theme(legend.position = c(0, 1),
         legend.justification = c(0,1),
         legend.background = element_rect(color = "grey20", size = 0.25),
         legend.box.margin = margin(rep(5, 4)))
@@ -258,8 +257,7 @@ if(skip_miQC){
     coord_cartesian(ylim = c(0,100)) +
     labs(x = "Number of genes detected",
          y = "Percent reads mitochondrial") +
-    theme(plot.margin = margin(rep(20, 4)),
-          legend.position = c(1, 1),
+    theme(legend.position = c(1, 1),
           legend.justification = c(1,1),
           legend.background = element_rect(color = "grey20", size = 0.25),
           legend.box.margin = margin(rep(5, 4)))

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -263,6 +263,12 @@ if(skip_miQC){
 }
 ```
 
+We calculate the probability that a cell is compromised due to degradation or rupture using [`miQC`](https://bioconductor.org/packages/release/bioc/html/miQC.html) ([Hippen _et al._ 2021](https://doi.org/10.1371/journal.pcbi.1009290)).
+This relies on fitting a mixture model using the number of genes expressed by a cell and the percentage of mitochondrial reads.
+The expected plot will show a characteristic triangular shape and two model fit lines.
+Cells with low numbers of genes expressed may have both low and high mitochondrial percentage, but cells with many genes tend to have a low mitochondrial percentage.
+If the model has failed to fit properly, the pattern of cells may differ, and there may only be one model fit line. 
+In such situations, the calculated probability of compromise may not be valid (see [miQC vignette](https://bioconductor.org/packages/3.13/bioc/vignettes/miQC/inst/doc/miQC.html#when-not-to-use-miqc) for more details).
 
 # Session Info
 <details>

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -80,10 +80,11 @@ sample_information <- tibble::tibble(
   t()
 
 # make table with sample information
-knitr::kable(sample_information) %>%
+knitr::kable(sample_information, align = 'r') %>%
   kableExtra::kable_styling(bootstrap_options = "striped",
                             full_width = FALSE,
-                            position = "left")
+                            position = "left") %>%
+  kableExtra::column_spec(2, monospace = TRUE)
 ```
 
 ## Pre-Processing Information
@@ -105,10 +106,11 @@ processing_info <- tibble::tibble(
 
 
 # make table with processing information
-knitr::kable(processing_info) %>%
+knitr::kable(processing_info, align = 'r') %>%
   kableExtra::kable_styling(bootstrap_options = "striped",
                             full_width = FALSE,
-                            position = "left")
+                            position = "left") %>%
+  kableExtra::column_spec(2, monospace = TRUE)
 ```
 
 # `r sample_id` Experiment Summary 
@@ -136,10 +138,11 @@ basic_statistics <- tibble::tibble(
 
 
 # make table with basic statistics
-knitr::kable(basic_statistics, align = "lr") %>%
+knitr::kable(basic_statistics, align = 'r') %>%
   kableExtra::kable_styling(bootstrap_options = "striped",
                             full_width = FALSE,
-                            position = "left")
+                            position = "left") %>%
+  kableExtra::column_spec(2, monospace = TRUE)
 
 ```
 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -218,6 +218,9 @@ ggplot(grouped_celldata, aes(x = med_rank, y = med_sum, color = pct_passed)) +
         legend.box.margin = margin(rep(5, 4)))
 ```
 
+The total UMI count of each droplet (barcode) plotted against the rank of that droplet allows visualization of the distribution of sequencing depth across droplets. 
+The droplets that are expected to contain cells were identified with [`DropletUtils::emptyDrops()`](https://bioconductor.org/packages/release/bioc/html/DropletUtils.html) , which uses both the total UMI counts and expressed gene content ([Lun  _et al._ 2019](https://doi.org/10.1186/s13059-019-1662-y)).
+As the boundary between droplets passing and failing this filter does not correspond only to the axes of this plot, some regions contain droplets in both categories, so we here color the plot by the percentage passing the filter.
 
 ## Cell Read Metrics 
 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -219,7 +219,8 @@ ggplot(grouped_celldata, aes(x = med_rank, y = med_sum, color = pct_passed)) +
 
 The total UMI count of each droplet (barcode) plotted against the rank of that droplet allows visualization of the distribution of sequencing depth across droplets. 
 The droplets that are expected to contain cells were identified with [`DropletUtils::emptyDrops()`](https://bioconductor.org/packages/release/bioc/html/DropletUtils.html), which uses both the total UMI counts and expressed gene content ([Lun  _et al._ 2019](https://doi.org/10.1186/s13059-019-1662-y)).
-As the boundary between droplets passing and failing this filter does not correspond only to the axes of this plot, some regions contain droplets in both categories, so we here color the plot by the percentage passing the filter.
+As the boundary between droplets passing and failing this filter is not solely dependent on total UMI count, some regions contain droplets in both categories.
+The color in this plot indicates the percentage of droplets in a region passing the filter.
 
 ## Cell Read Metrics 
 
@@ -243,7 +244,7 @@ ggplot(filtered_celldata,
 
 The above plot of cell metrics includes only droplets which have passed the `emptyDrops()` filter.
 The plot will usually display a strong (but curved) relationship between the total UMI count and the number of genes detected.
-Cells with low counts and high mitochondrial percentages may require further filtering.
+Cells with low UMI counts and high mitochondrial percentages may require further filtering.
 
 ## miQC Model Diagnostics
 
@@ -268,6 +269,8 @@ We calculate the probability that a cell is compromised due to degradation or ru
 This relies on fitting a mixture model using the number of genes expressed by a cell and the percentage of mitochondrial reads.
 The expected plot will show a characteristic triangular shape and two model fit lines.
 Cells with low numbers of genes expressed may have both low and high mitochondrial percentage, but cells with many genes tend to have a low mitochondrial percentage.
+Compromised cells are likely to have a fewer genes detected and higher percentage of mitochondrial reads.
+
 If the model has failed to fit properly, the pattern of cells may differ, and there may only be one model fit line. 
 In such situations, the calculated probability of compromise may not be valid (see [miQC vignette](https://bioconductor.org/packages/3.13/bioc/vignettes/miQC/inst/doc/miQC.html#when-not-to-use-miqc) for more details).
 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -161,16 +161,16 @@ unfiltered_celldata <- data.frame(colData(unfiltered_sce)) %>%
   arrange(desc(rank))
 
 ggplot(unfiltered_celldata, aes(x = rank, y = sum, color = filter_status))+
-  geom_point(aes(shape = filter_status),alpha = 0.2, size = 2) +
+  geom_point(aes(size = filter_status), alpha = 0.2) +
   scale_x_log10(labels = scales::label_number()) +
   scale_y_log10(labels = scales::label_number()) + 
   scale_color_manual(values = c("darkgreen", "grey80")) + 
-  scale_shape_manual(values = c(16, 1)) + # filled and unfilled circles
+  scale_size_manual(values = c(2, 1)) +
   labs(
     x = "Rank", 
     y = "Total UMI count",
     color = "Filter status",
-    shape = "Filter status"
+    size  = "Filter status"
   ) + 
   guides(color = guide_legend(override.aes = list(alpha = 1))) + 
   theme(legend.position = c(0, 0),

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -146,7 +146,6 @@ knitr::kable(basic_statistics, align = 'r') %>%
 
 ```
 
-
 ## Knee Plot
 
 ```{r, fig.alt="Knee plot of filtered and unfiltered droplets"}
@@ -242,6 +241,10 @@ ggplot(filtered_celldata,
         legend.background = element_rect(color = "grey20", size = 0.25),
         legend.box.margin = margin(rep(5, 4)))
 ```
+
+The above plot of cell metrics includes only droplets which have passed the `emptyDrops()` filter.
+The plot will usually display a strong (but curved) relationship between the total UMI count and the number of genes detected.
+Cells with low counts and high mitochondrial percentages may require further filtering.
 
 ## miQC Model Diagnostics
 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -180,18 +180,26 @@ ggplot(unfiltered_celldata, aes(x = rank, y = sum, color = filter_status))+
         legend.box.margin = margin(rep(5, 4)))
 ```
 
-```{r, fig.alt="Smoothed knee plot of filtered and unfiltered droplets"}}
+```{r, fig.alt="Smoothed knee plot of filtered and unfiltered droplets"}
 grouped_celldata <- unfiltered_celldata %>%
   select(sum, rank, filter_status) %>%
   mutate(rank_group = floor(rank / 100) )%>%
   group_by(rank_group) %>%
   summarize(
-    mean_sum = mean(sum),
-    mean_rank = mean(rank),
-    mean_passed = sum(filter_status == "Passed") / n() * 100
+    med_sum = median(sum),
+    med_rank = median(rank),
+    pct_passed = sum(filter_status == "Passed") / n() * 100
   )
 
-ggplot(grouped_celldata, aes(x = mean_rank, y = mean_sum, color = mean_passed)) + 
+top_celldata <- unfiltered_celldata %>%
+  select(sum, rank, filter_status) %>%
+  filter(rank <= 50) %>%
+  mutate(filter_status = ifelse(filter_status == "Passed", 100, 0))
+
+ggplot(grouped_celldata, aes(x = med_rank, y = med_sum, color = pct_passed)) + 
+  geom_point(mapping = aes(x = rank, y = sum, color = filter_status),
+             data = top_celldata,
+             alpha = 0.5) + 
   geom_line(size = 2, lineend = "round", linejoin= "round") +
   scale_x_log10(labels = scales::label_number()) +
   scale_y_log10(labels = scales::label_number(accuracy = 1)) + 


### PR DESCRIPTION
Here I am adding explanatory captions to the QC report for each plot. These captions may or may not be ideal, so editing suggestions are encouraged!

I have for now included both versions of the knee plot, but I am definitely leaning toward the smoothed version, which is what I refer to in the caption. I think it better shows where the bulk of cells are coming from vs. being filtered out. On the other hand, there are a lot of droplets with lower counts that make it through, because there are a **lot** of droplets with lower counts! Anyhow, compare for yourself in the attached file:

[SCPCL000001_qc.html.zip](https://github.com/AlexsLemonade/scpcaTools/files/7288209/SCPCL000001_qc.html.zip)

I also made a few small aesthetic changes: 
- All parameter/statistic tables now use monospace fonts and right justification for the "values" column.
- Table of contents starts expanded.


Are there other places where we should add explanatory text?

Filing as a draft until we resolve the knee plot question.


