### PR TITLE
Add a CITE-seq section to the QC report

### DIFF
--- a/inst/rmd/cite_qc.rmd
+++ b/inst/rmd/cite_qc.rmd
@@ -1,6 +1,7 @@
 # CITE-seq Experiment Summary
 
 ## CITE-seq Statistics
+
 ```{r}
 cite_exp <- altExp(filtered_sce, "CITEseq")
 cite_meta <- metadata(cite_exp)
@@ -10,7 +11,7 @@ if (is.null(rowData(cite_exp)$detected)){
   cite_exp <- scuttle::addPerFeatureQCMetrics(cite_exp)
 }
 
-cell_adt_counts <- colSums(counts(cite_exp))
+cell_adt_counts <- Matrix::colSums(counts(cite_exp))
 
 cite_information <- tibble::tibble(
   "Number of ADTs assayed" = 
@@ -31,7 +32,7 @@ cite_information <- tibble::tibble(
 knitr::kable(cite_information, align = 'r') %>%
   kableExtra::kable_styling(bootstrap_options = "striped",
                             full_width = FALSE,
-                            position = "left")
+                            position = "left") %>%
   kableExtra::column_spec(2, monospace = TRUE)
 ```
 
@@ -42,8 +43,8 @@ antibody_tags <- as.data.frame(rowData(cite_exp)) %>%
   select("Antibody",
          "Percent of cells detected" = detected) %>%
   # sort by leading characters, then numeric portion
-  arrange(stringr::str_extract(`Antibody tag`, "^[A-Za-z]+"),
-          as.numeric(stringr::str_extract(`Antibody tag`, "\\d+")))
+  arrange(stringr::str_extract(Antibody, "^[A-Za-z]+"),
+          as.numeric(stringr::str_extract(Antibody, "\\d+")))
 
 knitr::kable(antibody_tags, digits = 2) %>%
   kableExtra::kable_styling(bootstrap_options = "striped",

--- a/inst/rmd/cite_qc.rmd
+++ b/inst/rmd/cite_qc.rmd
@@ -1,7 +1,8 @@
-## CITE-seq statistics
+# CITE-seq Experiment Summary
 
+## CITE-seq Statistics
 ```{r}
-cite_exp <- altExp(filtered_sce2, "CITEseq")
+cite_exp <- altExp(filtered_sce, "CITEseq")
 cite_meta <- metadata(cite_exp)
 
 # add rowData if missing
@@ -30,15 +31,15 @@ cite_information <- tibble::tibble(
 knitr::kable(cite_information, align = 'r') %>%
   kableExtra::kable_styling(bootstrap_options = "striped",
                             full_width = FALSE,
-                            position = "left") %>%
+                            position = "left")
   kableExtra::column_spec(2, monospace = TRUE)
 ```
 
-
+## Antibody Derived Tag Statistics 
 ```{r}
 antibody_tags <- as.data.frame(rowData(cite_exp)) %>%
-  tibble::rownames_to_column("Antibody tag") %>%
-  select("Antibody tag",
+  tibble::rownames_to_column("Antibody") %>%
+  select("Antibody",
          "Percent of cells detected" = detected) %>%
   # sort by leading characters, then numeric portion
   arrange(stringr::str_extract(`Antibody tag`, "^[A-Za-z]+"),
@@ -48,6 +49,8 @@ knitr::kable(antibody_tags, digits = 2) %>%
   kableExtra::kable_styling(bootstrap_options = "striped",
                             full_width = FALSE,
                             position = "left") %>%
-  kableExtra::column_spec(2, monospace = TRUE)
+  kableExtra::column_spec(2, monospace = TRUE) %>%
+  kableExtra::scroll_box(height = "500px", fixed_thead = TRUE)
+  
 ```
 

--- a/inst/rmd/cite_qc.rmd
+++ b/inst/rmd/cite_qc.rmd
@@ -1,7 +1,41 @@
 ## CITE-seq statistics
 
 ```{r}
-cite_exp <- altExp(filtered_sce, "CITEseq")
+cite_exp <- altExp(filtered_sce2, "CITEseq")
+cite_meta <- metadata(cite_exp)
+
+# add rowData if missing
+if (is.null(rowData(cite_exp)$detected)){
+  cite_exp <- scuttle::addPerFeatureQCMetrics(cite_exp)
+}
+
+cell_adt_counts <- colSums(counts(cite_exp))
+
+cite_information <- tibble::tibble(
+  "Number of ADTs assayed" = 
+    format(nrow(cite_exp), big.mark = ',', scientific = FALSE),
+  "CITE-seq reads sequenced" = 
+    format(cite_meta$total_reads, big.mark = ',', scientific = FALSE),
+  "Percent CITE-seq reads mapped to ADTs" = 
+    paste0(round(cite_meta$mapped_reads/cite_meta$total_reads * 100, digits = 2), "%"),
+  "Percent of ADTs in cells" = 
+    paste0(round(sum(cell_adt_counts)/cite_meta$mapped_reads * 100, digits = 2), "%"),
+  "Percent of cells with ADTs" = 
+    paste0(round(sum(cell_adt_counts > 0)/length(cell_adt_counts) * 100, digits = 2), "%"),
+  "Median ADT UMIs per cell" = 
+    format(median(cell_adt_counts), big.mark = ',', scientific = FALSE)
+  )%>%
+  t()
+
+knitr::kable(cite_information, align = 'r') %>%
+  kableExtra::kable_styling(bootstrap_options = "striped",
+                            full_width = FALSE,
+                            position = "left") %>%
+  kableExtra::column_spec(2, monospace = TRUE)
+```
+
+
+```{r}
 antibody_tags <- as.data.frame(rowData(cite_exp)) %>%
   tibble::rownames_to_column("Antibody tag") %>%
   select("Antibody tag",
@@ -13,6 +47,7 @@ antibody_tags <- as.data.frame(rowData(cite_exp)) %>%
 knitr::kable(antibody_tags, digits = 2) %>%
   kableExtra::kable_styling(bootstrap_options = "striped",
                             full_width = FALSE,
-                            position = "left")
+                            position = "left") %>%
+  kableExtra::column_spec(2, monospace = TRUE)
 ```
 

--- a/inst/rmd/cite_qc.rmd
+++ b/inst/rmd/cite_qc.rmd
@@ -1,0 +1,18 @@
+## CITE-seq statistics
+
+```{r}
+cite_exp <- altExp(filtered_sce, "CITEseq")
+antibody_tags <- as.data.frame(rowData(cite_exp)) %>%
+  tibble::rownames_to_column("Antibody tag") %>%
+  select("Antibody tag",
+         "Percent of cells detected" = detected) %>%
+  # sort by leading characters, then numeric portion
+  arrange(stringr::str_extract(`Antibody tag`, "^[A-Za-z]+"),
+          as.numeric(stringr::str_extract(`Antibody tag`, "\\d+")))
+
+knitr::kable(antibody_tags, digits = 2) %>%
+  kableExtra::kable_styling(bootstrap_options = "striped",
+                            full_width = FALSE,
+                            position = "left")
+```
+

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -40,7 +40,7 @@ unfiltered_sce <- params$unfiltered_sce
 filtered_sce <- params$filtered_sce
 
 has_filtered <- !is.null(filtered_sce)
-has_cite <- "CITEseq" %in% altExpNames(filtered_sce)
+
 
 # if there is no filtered sce, use the unfiltered for both
 if (!has_filtered){
@@ -61,6 +61,14 @@ if (is.null(filtered_sce$sum)){
 if (is.null(metadata(filtered_sce)$miQC_model) & !skip_miQC){
   metadata(filtered_sce)$miQC_model <- miQC::mixtureModel(filtered_sce)
 }
+
+## Check for additional modalities
+modalities <- c("RNA-seq")
+
+has_cite <- "CITEseq" %in% altExpNames(filtered_sce)
+if (has_cite){
+  modalities <- c(modalities, "CITE-seq")
+}
 ```
 
 # Processing Information for `r sample_id`
@@ -74,6 +82,7 @@ unfiltered_meta <- metadata(unfiltered_sce)
 sample_information <- tibble::tibble(
   "Sample id" = sample_id,
   "Tech version" = format(unfiltered_meta$tech_version), # format to keep nulls
+  "Data modalities" = paste(modalities, collapse = ", "),
   "Number of reads sequenced" = format(unfiltered_meta$total_reads, big.mark = ',', scientific = FALSE),
   "Percent of reads mapped" = paste0(round((unfiltered_meta$mapped_reads/unfiltered_meta$total_reads) *100, 2), "%"),
   "Number of cells reported by alevin-fry" = format(unfiltered_meta$af_num_cells, big.mark = ',', scientific = FALSE)
@@ -286,8 +295,6 @@ In such situations, the calculated probability of compromise may not be valid (s
 <!-- Next section included only if CITE-seq data is present -->
 ```{r, child='cite_qc.rmd', eval = has_cite}
 ```
-
-
 
 
 # Session Info

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -40,6 +40,7 @@ unfiltered_sce <- params$unfiltered_sce
 filtered_sce <- params$filtered_sce
 
 has_filtered <- !is.null(filtered_sce)
+has_cite <- "CITEseq" %in% altExpNames(filtered_sce)
 
 # if there is no filtered sce, use the unfiltered for both
 if (!has_filtered){
@@ -76,7 +77,17 @@ sample_information <- tibble::tibble(
   "Number of reads sequenced" = format(unfiltered_meta$total_reads, big.mark = ',', scientific = FALSE),
   "Percent of reads mapped" = paste0(round((unfiltered_meta$mapped_reads/unfiltered_meta$total_reads) *100, 2), "%"),
   "Number of cells reported by alevin-fry" = format(unfiltered_meta$af_num_cells, big.mark = ',', scientific = FALSE)
-) %>%
+)
+if (has_cite){
+  cite_meta <- metadata(altExp(unfiltered_sce, "CITEseq"))
+  sample_information <- sample_information %>%
+    mutate(
+      "CITE-seq reads sequenced" = format(cite_meta$total_reads, big.mark = ',', scientific = FALSE),
+      "CITE-seq reads mapped" = format(cite_meta$mapped_reads, big.mark = ',', scientific = FALSE),
+    )
+}
+
+sample_information <- sample_information %>%
   mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) %>% # reformat nulls
   t()
 
@@ -270,6 +281,12 @@ The expected plot will show a characteristic triangular shape and two model fit 
 Cells with low numbers of genes expressed may have both low and high mitochondrial percentage, but cells with many genes tend to have a low mitochondrial percentage.
 If the model has failed to fit properly, the pattern of cells may differ, and there may only be one model fit line. 
 In such situations, the calculated probability of compromise may not be valid (see [miQC vignette](https://bioconductor.org/packages/3.13/bioc/vignettes/miQC/inst/doc/miQC.html#when-not-to-use-miqc) for more details).
+
+```{r cite-seq, child='cite_qc.rmd', eval = has_cite}
+```
+
+
+
 
 # Session Info
 <details>

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -282,7 +282,9 @@ Cells with low numbers of genes expressed may have both low and high mitochondri
 If the model has failed to fit properly, the pattern of cells may differ, and there may only be one model fit line. 
 In such situations, the calculated probability of compromise may not be valid (see [miQC vignette](https://bioconductor.org/packages/3.13/bioc/vignettes/miQC/inst/doc/miQC.html#when-not-to-use-miqc) for more details).
 
-```{r cite-seq, child='cite_qc.rmd', eval = has_cite}
+
+<!-- Next section included only if CITE-seq data is present -->
+```{r, child='cite_qc.rmd', eval = has_cite}
 ```
 
 


### PR DESCRIPTION
Note: stacked on #60


Here I am adding a section with CITE-seq statistics for samples that have them. 
I did this partly by adding a separate document with the CITE-seq content, which is then included conditionally as a "child" document.

The content in that chunk includes a table that is a bit of a hybrid of the `sample_information` and `basic_statistics` tables from the main page. I thought that separating out into two tables was probably not required here, as I didn't want to add too much. I think this covers the highlights of the fields that Cell Ranger reports. 

The second table shows the % of cells with each ADT detected. I made this table more compact so it doesn't take up too much space. If we still think it is too big, we could make it scroll, though it looked a bit ugly when I did that.

You might notice some tortured logic in there to get the ADT sorting as I wanted it, which is basically alphabetical with natural number sorting (i.e. CD2 comes before CD15). I hope that will hold up to future data sets! An alternative would be to just rank by the detected value. 

Other random thoughts:
- I added a line for "modalities" in the main `sample_information` table. Do we like that? 
- Header names? Maybe we should change "SCPCL00000 Experiment Summary" to  RNA-seq experiment summary?
- Do we still need the  text under the experiment summary? https://github.com/AlexsLemonade/scpcaTools/blob/94bc15743bbdacf6200db7f68db8eecefbaaeb04/inst/rmd/qc_report.rmd#L115-L121

Example report: [SCPCL000050_qc.html.zip](https://github.com/AlexsLemonade/scpcaTools/files/7289174/SCPCL000050_qc.html.zip)

Closes #38