### PR TITLE
Add seed to arguments for `filter_counts`

### DIFF
--- a/R/filter_counts.R
+++ b/R/filter_counts.R
@@ -3,6 +3,7 @@
 #' @param sce SingleCellExperiment with unfiltered gene x cell counts matrix.
 #' @param fdr_cutoff FDR cutoff to use for DropletUtils::emptyDrops.
 #'   Default is 0.01.
+#' @param seed A random seed for reproducibility.
 #' @param ... Any arguments to be passed into DropletUtils::emptyDrops.
 #'
 #' @return SingleCellExperiment with filtered gene x cell matrix.
@@ -12,7 +13,9 @@
 #' \dontrun{
 #' filter_counts(sce = sce_object)
 #' }
-filter_counts <- function(sce, fdr_cutoff = 0.01, ...) {
+filter_counts <- function(sce, fdr_cutoff = 0.01, seed = NULL, ...) {
+
+  set.seed(seed)
 
   if(!is(sce,"SingleCellExperiment")){
     stop("Input must be a SingleCellExperiment object.")

--- a/man/filter_counts.Rd
+++ b/man/filter_counts.Rd
@@ -4,13 +4,15 @@
 \alias{filter_counts}
 \title{Filter counts matrix using DropletUtils::emptyDrops}
 \usage{
-filter_counts(sce, fdr_cutoff = 0.01, ...)
+filter_counts(sce, fdr_cutoff = 0.01, seed = NULL, ...)
 }
 \arguments{
 \item{sce}{SingleCellExperiment with unfiltered gene x cell counts matrix.}
 
 \item{fdr_cutoff}{FDR cutoff to use for DropletUtils::emptyDrops.
 Default is 0.01.}
+
+\item{seed}{A random seed for reproducibility.}
 
 \item{...}{Any arguments to be passed into DropletUtils::emptyDrops.}
 }


### PR DESCRIPTION
Closes #61. As we had discussed previously it would be good to add in an option to set the seed within the `filter_counts` function before running `emptyDrops`. Here, I am adding in an argument for the seed and setting the default to `NULL` and then setting the seed at the beginning of the script. I believe we also talked about not needing error checks for this so I didn't add any in, but let me know if there is an error check we should have for this. 