### PR TITLE
Keep fewer images on ghcr

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -34,8 +34,6 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=sha
-            type=raw,value={{date 'YYYY-MM-DD'}}
             type=semver,pattern={{raw}}
             type=edge,branch=main
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,7 +10,6 @@ docker build . -t scpca-tools
 
 Note that this image does not include RStudio, in attempt to make the image smaller. 
 
-This image is built automatically on every update to `scpcaTools` (`main`) and pushed to `ghcr.io/alexslemonade/scpca-tools:edge` 
-(also tagged by date and short commit hash).
+This image is built automatically on every update to `scpcaTools` (`main`) and pushed to `ghcr.io/alexslemonade/scpca-tools:edge`.
 
 Release versions of `scpcaTools` will be tagged as `ghcr.io/alexslemonade/scpca-tools:latest` and tagged by version number.


### PR DESCRIPTION
Now that we have some releases under our belt, I think that the practice of keeping docker images for every release may have outlived its usefulness. So here I am removing tagging images built at every push to main with the sha hash and date. The images are still built and pushed with the `edge` tag, but this will mean that we will not keep around every single version: just the ones tagged as releases and the most recent as `edge`.

My motivation here is based on a few thoughts: One is that I believe we pay for storage, and while the dependency layers (where most of the size is) should not change often, they may nonetheless accumulate. (I do not know where to find the current usage, so I don't know how to monitor this.) Maybe more importantly, the list of tagged is getting long, and most (all?) of those have never been used explicitly. We tend to use either `edge` or one of the release tagged versions.

Happy to discuss this in more depth, but since the change was so small, I thought a PR made as much sense as an issue. 