### PR TITLE
Minor QC report updates

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scpcaTools
 Type: Package
 Title: Single cell data tools for ScPCA
-Version: 0.1.0
+Version: 0.1.2
 Authors@R: c(
     person("Ally", "Hawkins",
            email = "ally.hawkins@ccdatalab.org",

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -199,7 +199,7 @@ ggplot(grouped_celldata, aes(x = med_rank, y = med_sum, color = pct_passed)) +
              data = top_celldata,
              alpha = 0.5) + 
   geom_line(size = 2, lineend = "round", linejoin= "round") +
-  scale_x_log10(labels = scales::label_number()) +
+  scale_x_log10(labels = scales::label_number(accuracy = 1)) +
   scale_y_log10(labels = scales::label_number(accuracy = 1)) + 
   scale_color_gradient2(low = "grey70", 
                         mid = "forestgreen", 
@@ -232,8 +232,8 @@ ggplot(filtered_celldata,
             color = subsets_mito_percent)) +
   geom_point(alpha = 0.3) +
   scale_color_viridis_c(limits = c(0, 100)) + 
-  scale_x_continuous(labels = scales::label_number()) +
-  scale_x_continuous(labels = scales::label_number()) +
+  scale_x_continuous(labels = scales::label_number(accuracy = 1)) +
+  scale_y_continuous(labels = scales::label_number(accuracy = 1)) +
   labs(x = "Total UMI count",
        y = "Number of genes detected",
        color = "Percent reads\nmitochondrial") + 
@@ -266,7 +266,7 @@ if(skip_miQC){
   
   miQC_plot + 
     coord_cartesian(ylim = c(0,100)) +
-    scale_x_continuous(labels = scales::label_number()) +
+    scale_x_continuous(labels = scales::label_number(accuracy = 1)) +
     labs(x = "Number of genes detected",
          y = "Percent reads mitochondrial") +
     theme(legend.position = c(1, 1),

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -21,8 +21,7 @@ output:
 ```{r setup, message = FALSE, echo = FALSE}
 # knitr options
 knitr::opts_chunk$set(
-  echo = FALSE,
-  warning = FALSE
+  echo = FALSE
 )
 
 library(SingleCellExperiment)

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -60,6 +60,11 @@ if (is.null(filtered_sce$subsets_mito_percent)){
   skip_miQC <- FALSE
 }
 
+# try to add miQC if it is missing
+if (is.null(metadata(filtered_sce)$miQC_model) & !skip_miQC){
+  filtered_sce <- scpcaTools::add_miQC(filtered_sce)
+}
+
 ## Check for additional modalities
 modalities <- c("RNA-seq")
 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -21,7 +21,8 @@ output:
 ```{r setup, message = FALSE, echo = FALSE}
 # knitr options
 knitr::opts_chunk$set(
-  echo = FALSE
+  echo = FALSE,
+  warning = FALSE
 )
 
 library(SingleCellExperiment)
@@ -52,14 +53,12 @@ if (is.null(unfiltered_sce$sum)){
 }
 if (is.null(filtered_sce$sum)){
   filtered_sce <- scuttle::addPerCellQCMetrics(filtered_sce)
+}
+if (is.null(filtered_sce$subsets_mito_percent)){
   filtered_sce$subsets_mito_percent <- NA_real_
   skip_miQC <- TRUE
-} else{
+}else{
   skip_miQC <- FALSE
-}
-# add miQC model if missing
-if (is.null(metadata(filtered_sce)$miQC_model) & !skip_miQC){
-  metadata(filtered_sce)$miQC_model <- miQC::mixtureModel(filtered_sce)
 }
 
 ## Check for additional modalities


### PR DESCRIPTION
Looking through the QC reports generated by v0.1.1, I saw a few little things that I wanted to fix.

One is that a missing miQC model gets fit with `add_miQC()` to handle any errors. In most cases, this would be a redundant step as the model fit has already failed and will likely fail again, but it seems like a good idea to preserve this functionality in case somebody wants to run this on a sample that they have not yet run miQC on. 

The other change is to add `accuracy=1` to more scales (and fix one x->y error) in the interests of uniform legend labels. Occasionally we would get a label of "100.0" etc, which we never really need.

Finally, I used this PR to bump the version number in the DESCRIPTION file, so that the next release will have the correct version ID in the package.