### PR TITLE
Add test for `filter_counts()` & removed outdated feature stats when filtering

### DIFF
--- a/R/filter_counts.R
+++ b/R/filter_counts.R
@@ -12,6 +12,9 @@
 #' @param ... Any arguments to be passed into DropletUtils::emptyDrops.
 #'
 #' @return SingleCellExperiment with filtered gene x cell matrix.
+#'
+#' @import SingleCellExperiment
+#'
 #' @export
 #'
 #' @examples
@@ -40,10 +43,9 @@ filter_counts <- function(sce, fdr_cutoff = 0.01, seed = NULL, ...) {
   # remove feature stats that are no longer valid
   drop_cols <- colnames(rowData(sce)) %in% c('mean', 'detected')
   rowData(sce) <- rowData(sce)[!drop_cols]
-  for (alt in alt_names) { # alt expts too
-    drop_cols = colnames(rowData(altExp(filtered_sce, alt))) %in% c('mean', 'detected')
-    rowData(altExp(filtered_sce, alt)) <- rowData(altExp(filtered_sce, alt))[!drop_cols]
+  for (alt in altExpNames(sce)) { # alt expts too
+    drop_cols = colnames(rowData(altExp(sce, alt))) %in% c('mean', 'detected')
+    rowData(altExp(sce, alt)) <- rowData(altExp(sce, alt))[!drop_cols]
   }
-
   return(sce)
 }

--- a/R/filter_counts.R
+++ b/R/filter_counts.R
@@ -35,6 +35,10 @@ filter_counts <- function(sce, fdr_cutoff = 0.01, seed = NULL, ...) {
   # remove feature stats that are no longer valid
   drop_cols <- colnames(rowData(sce)) %in% c('mean', 'detected')
   rowData(sce) <- rowData(sce)[!drop_cols]
+  for (alt in alt_names) { # alt expts too
+    drop_cols = colnames(rowData(altExp(filtered_sce, alt))) %in% c('mean', 'detected')
+    rowData(altExp(filtered_sce, alt)) <- rowData(altExp(filtered_sce, alt))[!drop_cols]
+  }
 
   return(sce)
 }

--- a/R/filter_counts.R
+++ b/R/filter_counts.R
@@ -31,5 +31,10 @@ filter_counts <- function(sce, fdr_cutoff = 0.01, seed = NULL, ...) {
 
   # subset original counts matrix by cells that pass filter
   sce <- sce[, cells]
+
+  # remove feature stats that are no longer valid
+  drop_cols <- colnames(rowData(sce)) %in% c('mean', 'detected')
+  rowData(sce) <- rowData(sce)[!drop_cols]
+
   return(sce)
 }

--- a/R/filter_counts.R
+++ b/R/filter_counts.R
@@ -1,5 +1,10 @@
 #' Filter counts matrix using DropletUtils::emptyDrops
 #'
+#' This function will filter a SingleCellExperiment object using DropletUtils::emptyDrops(),
+#'   as well as any associated alternative experiments. If mean expression and percent detected
+#'   were previously calculated in the columns `mean` and `detected`, respectively, these
+#'   will be removed from both the main and alternative experiments.
+#'
 #' @param sce SingleCellExperiment with unfiltered gene x cell counts matrix.
 #' @param fdr_cutoff FDR cutoff to use for DropletUtils::emptyDrops.
 #'   Default is 0.01.

--- a/man/filter_counts.Rd
+++ b/man/filter_counts.Rd
@@ -20,7 +20,10 @@ Default is 0.01.}
 SingleCellExperiment with filtered gene x cell matrix.
 }
 \description{
-Filter counts matrix using DropletUtils::emptyDrops
+This function will filter a SingleCellExperiment object using DropletUtils::emptyDrops(),
+  as well as any associated alternative experiments. If mean expression and percent detected
+  were previously calculated in the columns `mean` and `detected`, respectively, these
+  will be removed from both the main and alternative experiments.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-filter_counts.R
+++ b/tests/testthat/test-filter_counts.R
@@ -3,9 +3,9 @@ sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 1000)
 
 test_that("Cell filtering is as expected", {
   filtered_sce <- filter_counts(sce)
-  expect_equal(ncol(filtered_sce), 100)
-  expect_equal(colnames(filtered_sce), colnames(sce)[1:100])
-  expect_equal(nrow(filtered_sce), 200)
+  expect_lt(ncol(filtered_sce), ncol(sce))
+  expect_true(all(colnames(filtered_sce) %in% colnames(sce)))
+  expect_equal(nrow(filtered_sce), nrow(sce))
 })
 
 test_that("Cell filtering removes row stats", {

--- a/tests/testthat/test-filter_counts.R
+++ b/tests/testthat/test-filter_counts.R
@@ -1,0 +1,16 @@
+set.seed(1665)
+sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 1000)
+
+test_that("Cell filtering is as expected", {
+  filtered_sce <- filter_counts(sce)
+  expect_equal(ncol(filtered_sce), 100)
+  expect_equal(colnames(filtered_sce), colnames(sce)[1:100])
+  expect_equal(nrow(filtered_sce), 200)
+})
+
+test_that("Cell filtering removes row stats", {
+  sce <- scuttle::addPerFeatureQCMetrics(sce)
+  filtered_sce <- filter_counts(sce)
+  expect_null(rowData(filtered_sce)$mean)
+  expect_null(rowData(filtered_sce)$detected)
+})


### PR DESCRIPTION
Closes #21

This PR adds some minimal tests for `filter_counts()` to assess that it is performing correctly (more or less). Given that the simulated sce does have empty drops, we can expect that at least some will be removed in filtering. (In practice, all should be, given the extreme nature of the simulation, but I didn't want the test to fail if a few were falsely included).
By contrast, all rows should be kept.

I also added removal of feature stats that are made invalid in the filtering, both for the main and alt experiments (though only the former is currently tested). We already handle this in use for scpca-nf, but it seemed like something that should be part of the function.
