### PR TITLE
Make emptyDropsCellRanger default filtering method 

### DIFF
--- a/man/filter_counts.Rd
+++ b/man/filter_counts.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/filter_counts.R
 \name{filter_counts}
 \alias{filter_counts}
-\title{Filter counts matrix using DropletUtils::emptyDrops}
+\title{Filter counts matrix using DropletUtils::emptyDropsCellRanger}
 \usage{
 filter_counts(sce, cr_like = TRUE, fdr_cutoff = 0.01, seed = NULL, ...)
 }
@@ -23,8 +23,8 @@ Default is 0.01.}
 SingleCellExperiment with filtered gene x cell matrix.
 }
 \description{
-This function will filter a SingleCellExperiment object using DropletUtils::emptyDrops(),
-  as well as any associated alternative experiments. If mean expression and percent detected
+This function will filter a SingleCellExperiment object using DropletUtils::emptyDropsCellRanger() by default,
+  or DropletUtils::emptyDrops(), as well as any associated alternative experiments. If mean expression and percent detected
   were previously calculated in the columns `mean` and `detected`, respectively, these
   will be removed from both the main and alternative experiments.
 }

--- a/man/filter_counts.Rd
+++ b/man/filter_counts.Rd
@@ -4,17 +4,20 @@
 \alias{filter_counts}
 \title{Filter counts matrix using DropletUtils::emptyDrops}
 \usage{
-filter_counts(sce, fdr_cutoff = 0.01, seed = NULL, ...)
+filter_counts(sce, cr_like = TRUE, fdr_cutoff = 0.01, seed = NULL, ...)
 }
 \arguments{
 \item{sce}{SingleCellExperiment with unfiltered gene x cell counts matrix.}
 
-\item{fdr_cutoff}{FDR cutoff to use for DropletUtils::emptyDrops.
+\item{cr_like}{Logical indicating whether or not to use DropletUtils::emptyDropsCellRanger.
+Default is set to TRUE.}
+
+\item{fdr_cutoff}{FDR cutoff to use for DropletUtils::emptyDropsCellRanger or DropletUtils::emptyDrops.
 Default is 0.01.}
 
 \item{seed}{An optional random seed for reproducibility.}
 
-\item{...}{Any arguments to be passed into DropletUtils::emptyDrops.}
+\item{...}{Any arguments to be passed into DropletUtils::emptyDropsCellRanger or DropletUtils::emptyDrops.}
 }
 \value{
 SingleCellExperiment with filtered gene x cell matrix.

--- a/tests/testthat/test-filter_counts.R
+++ b/tests/testthat/test-filter_counts.R
@@ -1,5 +1,5 @@
 set.seed(1665)
-sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 100)
+sce <- sim_sce(n_cells = 200, n_genes = 200, n_empty = 100000)
 
 test_that("Cell filtering with emptyDropsCellRanger() is as expected", {
   filtered_sce <- filter_counts(sce)

--- a/tests/testthat/test-filter_counts.R
+++ b/tests/testthat/test-filter_counts.R
@@ -1,5 +1,5 @@
 set.seed(1665)
-sce <- sim_sce(n_cells = 1000, n_genes = 200, n_empty = 100)
+sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 100)
 
 test_that("Cell filtering with emptyDropsCellRanger() is as expected", {
   filtered_sce <- filter_counts(sce)

--- a/tests/testthat/test-filter_counts.R
+++ b/tests/testthat/test-filter_counts.R
@@ -1,8 +1,15 @@
 set.seed(1665)
-sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 1000)
+sce <- sim_sce(n_cells = 1000, n_genes = 200, n_empty = 100)
 
-test_that("Cell filtering is as expected", {
+test_that("Cell filtering with emptyDropsCellRanger() is as expected", {
   filtered_sce <- filter_counts(sce)
+  expect_lt(ncol(filtered_sce), ncol(sce))
+  expect_true(all(colnames(filtered_sce) %in% colnames(sce)))
+  expect_equal(nrow(filtered_sce), nrow(sce))
+})
+
+test_that("Cell filtering with emptyDrops() is as expected", {
+  filtered_sce <- filter_counts(sce, cr_like = FALSE)
   expect_lt(ncol(filtered_sce), ncol(sce))
   expect_true(all(colnames(filtered_sce) %in% colnames(sce)))
   expect_equal(nrow(filtered_sce), nrow(sce))


### PR DESCRIPTION
Closes #73. Here I have modified the filtering function to use `DropletUtils::emtpyDropsCellRanger` as the default filtering method with the option of using `emptyDrops` instead. I added an argument `cr_like` that by default is set to `TRUE` and when set to `FALSE`, filtering will be performed using `emptyDrops`. 

I'm leaving this as a draft PR right now because this does not pass all of the checks with the test functions. In working on this, I noticed that `emptyDropsCellRanger` does not always work as expected. We have a test function that creates a fake sce object and for some reason when trying to apply `emptyDropsCellRanger` to the counts from this fake sce object, I'm getting the following errors: 

``` 
 Error in if (any(still.zero)) { : missing value where TRUE/FALSE needed 
```
This is the same error I was receiving previously when working with `emptyDropsCellRanger()` when there was a bug in the code, which I checked and this version has the [correction in the ambient function that I had noted on their PR previously](https://github.com/MarioniLab/DropletUtils/pull/66#issuecomment-911793467). If I use a real sce (from one of our real samples) or if I create simulated counts using `DropletUtils:::simCounts()` then this works without issue but I can't find any obvious differences between the counts from using `DropletUtils:::simCounts()` and `scpcaTools::sim_sce()`. They are both sparse matrices with genes as the rows and cells as the columns. I think there may be an issue with how we create our simulated sce object that could be causing an issue but I'm not quite sure where that issue is. I'm going to leave this in draft state as I work on that and to see if anyone else has any thoughts on this. 