### PR TITLE
Round counts for alevin import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scpcaTools
 Type: Package
 Title: Single cell data tools for ScPCA
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(
     person("Ally", "Hawkins",
            email = "ally.hawkins@ccdatalab.org",

--- a/R/read_alevin.R
+++ b/R/read_alevin.R
@@ -12,6 +12,8 @@
 #'   only counts aligned to spliced cDNA ("spliced") or all spliced and unspliced cDNA ("unspliced").
 #'   Applies if `intron_mode` or `usa_mode` is TRUE.
 #'   Default is "spliced".
+#' @param round_counts Logical indicating in the count matrix should be rounded to integers on import.
+#'   Default is TRUE.
 #' @param tech_version Technology or kit used to process library (i.e. 10Xv3, 10Xv3.1).
 #'
 #' @return SingleCellExperiment of unfiltered gene x cell counts matrix.
@@ -45,6 +47,7 @@ read_alevin <- function(quant_dir,
                         intron_mode = FALSE,
                         usa_mode = FALSE,
                         which_counts = c("spliced", "unspliced"),
+                        round_counts = TRUE,
                         tech_version = NULL){
 
   which_counts <- match.arg(which_counts)
@@ -58,6 +61,9 @@ read_alevin <- function(quant_dir,
   }
   if(!is.logical(usa_mode)){
     stop("usa_mode must be set as TRUE or FALSE")
+  }
+  if(!is.logical(round_counts)){
+    stop("round_counts must be set as TRUE or FALSE")
   }
 
   # check that usa_mode and intron_mode are not used together
@@ -85,6 +91,10 @@ read_alevin <- function(quant_dir,
   if (intron_mode | usa_mode) {
     counts <- collapse_intron_counts(counts, which_counts)
     meta$transcript_type <- which_counts
+  }
+
+  if (round_counts){
+    counts <- round(counts)
   }
 
   # make the SCE object

--- a/man/read_alevin.Rd
+++ b/man/read_alevin.Rd
@@ -10,6 +10,7 @@ read_alevin(
   intron_mode = FALSE,
   usa_mode = FALSE,
   which_counts = c("spliced", "unspliced"),
+  round_counts = TRUE,
   tech_version = NULL
 )
 }
@@ -30,6 +31,9 @@ Default is FALSE.}
 only counts aligned to spliced cDNA ("spliced") or all spliced and unspliced cDNA ("unspliced").
 Applies if `intron_mode` or `usa_mode` is TRUE.
 Default is "spliced".}
+
+\item{round_counts}{Logical indicating in the count matrix should be rounded to integers on import.
+Default is TRUE.}
 
 \item{tech_version}{Technology or kit used to process library (i.e. 10Xv3, 10Xv3.1).}
 }


### PR DESCRIPTION
Closes #85 

This PR updates the alevin import function to add an option to round the imported data to integers before creating a `SingleCellExperiment` object. Since I don't think either kallisto or cellranger create non-integer counts, I didn't update those. 

I chose to update only the top-level function that creates the SCE itself (rather than the subfunctions that do the reading from alevin output) in order to preserve precision at the `collapse_intron_counts` step. 

As implemented, this _should_ require no changes to downstream scripts in `scpca-nf`, though we will want to update `scpca-docs` to indicate that all counts are rounded.