### PR TITLE
Temporarily handle failure for `emptyDrops`

### DIFF
--- a/R/filter_counts.R
+++ b/R/filter_counts.R
@@ -37,8 +37,8 @@ filter_counts <- function(sce, cr_like = TRUE, fdr_cutoff = 0.01, seed = NULL, u
     stop("cr_like must be set as TRUE or FALSE")
   }
 
-  if(!is.numeric(umi_cutoff) & umi_cutoff >= 0){
-    stop("umi_cutoff must be an integer greater than or equal to 0")
+  if(!is.numeric(umi_cutoff) | umi_cutoff < 0){
+    stop("umi_cutoff must be a number greater than or equal to 0")
   }
 
 

--- a/R/filter_counts.R
+++ b/R/filter_counts.R
@@ -11,7 +11,7 @@
 #' @param fdr_cutoff FDR cutoff to use for DropletUtils::emptyDropsCellRanger or DropletUtils::emptyDrops.
 #'   Default is 0.01.
 #' @param seed An optional random seed for reproducibility.
-#' @param umi_cutoff The minimum UMI count for cells to pass filtering, only used if emptyDropsCellRanger and emptyDrops fails.
+#' @param umi_cutoff The minimum UMI count for cells to pass filtering, only used if emptyDropsCellRanger or emptyDrops fails.
 #'   Default is 100.
 #' @param ... Any arguments to be passed into DropletUtils::emptyDropsCellRanger or DropletUtils::emptyDrops.
 #'
@@ -25,7 +25,7 @@
 #' \dontrun{
 #' filter_counts(sce = sce_object)
 #' }
-filter_counts <- function(sce, cr_like = TRUE, fdr_cutoff = 0.01, seed = NULL, umi_cutoff= 100, ...) {
+filter_counts <- function(sce, cr_like = TRUE, fdr_cutoff = 0.01, seed = NULL, umi_cutoff = 100, ...) {
 
   set.seed(seed)
 

--- a/R/filter_counts.R
+++ b/R/filter_counts.R
@@ -68,6 +68,7 @@ filter_counts <- function(sce, cr_like = TRUE, fdr_cutoff = 0.01, seed = NULL, u
     cells <- sce$sum > umi_cutoff
     # replace filtering method with UMI cutoff as method
     metadata(sce)$filtering_method <- "UMI cutoff"
+    metadata(sce)$umi_cutoff <- umi_cutoff
   }
 
   # subset original counts matrix by cells that pass filter

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -174,9 +174,16 @@ knitr::kable(basic_statistics, align = 'r') |>
 
 ```
 
-```{r}
-if(metadata(filtered_sce)$filtering_method %in% "UMI cutoff"){
-  message(glue::glue("This library may contain a low number of droplets and was unable to be filtered using `DropletUtils`. Cells with a total UMI count > {metadata(filtered_sce)$umi_cutoff} are included in the filtered `SingleCellExperiment` object."))
+```{r, results='asis'}
+if(metadata(filtered_sce)$filtering_method == "UMI cutoff"){
+  glue::glue("
+    <div class=\"alert alert-warning\">
+    
+    This library may contain a low number of cells and was unable to be filtered using `DropletUtils`. 
+    Droplets with a total UMI count ≥ {metadata(filtered_sce)$umi_cutoff} are included in the filtered `SingleCellExperiment` object.
+    
+    </div>
+  ")
 }
 ```
 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -129,7 +129,7 @@ processing_info <- tibble::tibble(
   "Salmon version"       = format(unfiltered_meta$salmon_version),
   "Alevin-fry version"   = format(unfiltered_meta$alevinfry_version),
   "Transcriptome index"  = format(unfiltered_meta$reference_index),
-  "Filtering method"     = format(unfiltered_meta$af_permit_type),
+  "Alevin-fry droplet detection"  = format(unfiltered_meta$af_permit_type),
   "Resolution"           = format(unfiltered_meta$af_resolution), 
   "Transcripts included" = dplyr::case_when(
       format(unfiltered_meta$transcript_type) == "spliced" ~ "Spliced only",
@@ -154,6 +154,7 @@ knitr::kable(processing_info, align = 'r') |>
 
 ```{r}
 basic_statistics <- tibble::tibble(
+  "Filtering method"                   = metadata(filtered_sce)$filtering_method, 
   "Number of cells post filtering"     = format(ncol(filtered_sce), big.mark = ","),
   "Percent of reads in cells"          = paste0(round((sum(filtered_sce$sum)/sum(unfiltered_sce$sum))*100,2),"%"),
   "Median UMI count per cell"          = format(median(filtered_sce$sum), big.mark = ","),
@@ -172,6 +173,13 @@ knitr::kable(basic_statistics, align = 'r') |>
   kableExtra::column_spec(2, monospace = TRUE)
 
 ```
+
+```{r}
+if(metadata(filtered_sce)$filtering_method %in% "UMI cutoff"){
+  message(glue::glue("This library may contain a low number of droplets and was unable to be filtered using `DropletUtils`. Cells with a total UMI count > {metadata(filtered_sce)$umi_cutoff} are included in the filtered `SingleCellExperiment` object."))
+}
+```
+
 
 ## Knee Plot
 

--- a/man/filter_counts.Rd
+++ b/man/filter_counts.Rd
@@ -4,7 +4,14 @@
 \alias{filter_counts}
 \title{Filter counts matrix using DropletUtils::emptyDropsCellRanger}
 \usage{
-filter_counts(sce, cr_like = TRUE, fdr_cutoff = 0.01, seed = NULL, ...)
+filter_counts(
+  sce,
+  cr_like = TRUE,
+  fdr_cutoff = 0.01,
+  seed = NULL,
+  umi_cutoff = 100,
+  ...
+)
 }
 \arguments{
 \item{sce}{SingleCellExperiment with unfiltered gene x cell counts matrix.}
@@ -16,6 +23,9 @@ Default is set to TRUE.}
 Default is 0.01.}
 
 \item{seed}{An optional random seed for reproducibility.}
+
+\item{umi_cutoff}{The minimum UMI count for cells to pass filtering, only used if emptyDropsCellRanger and emptyDrops fails.
+Default is 100.}
 
 \item{...}{Any arguments to be passed into DropletUtils::emptyDropsCellRanger or DropletUtils::emptyDrops.}
 }

--- a/tests/testthat/test-filter_counts.R
+++ b/tests/testthat/test-filter_counts.R
@@ -6,6 +6,7 @@ test_that("Cell filtering with emptyDropsCellRanger() is as expected", {
   expect_lt(ncol(filtered_sce), ncol(sce))
   expect_true(all(colnames(filtered_sce) %in% colnames(sce)))
   expect_equal(nrow(filtered_sce), nrow(sce))
+  expect_true(metadata(filtered_sce)$filtering_method == "emptyDropsCellRanger")
 })
 
 test_that("Cell filtering with emptyDrops() is as expected", {
@@ -13,6 +14,16 @@ test_that("Cell filtering with emptyDrops() is as expected", {
   expect_lt(ncol(filtered_sce), ncol(sce))
   expect_true(all(colnames(filtered_sce) %in% colnames(sce)))
   expect_equal(nrow(filtered_sce), nrow(sce))
+  expect_true(metadata(filtered_sce)$filtering_method == "emptyDrops")
+})
+
+test_that("Cell filtering with UMI cutoff is as expected", {
+  low_cells_sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 10000)
+  low_cells_filtered_sce <- filter_counts(low_cells_sce)
+  expect_lt(ncol(low_cells_filtered_sce), ncol(low_cells_sce))
+  expect_true(all(colnames(low_cells_filtered_sce) %in% colnames(low_cells_sce)))
+  expect_equal(nrow(low_cells_filtered_sce), nrow(low_cells_sce))
+  expect_true(metadata(low_cells_filtered_sce)$filtering_method == "UMI cutoff")
 })
 
 test_that("Cell filtering removes row stats", {

--- a/tests/testthat/test-generate_qc_report.R
+++ b/tests/testthat/test-generate_qc_report.R
@@ -1,6 +1,6 @@
 set.seed(1665)
-sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 0)
-filt_sce <- sce[,1:50]
+sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 10)
+filt_sce <- filter_counts(sce)
 
 test_that("generating a qc report works", {
   qc_file <- generate_qc_report(sample_name = "TEST",


### PR DESCRIPTION
Closes #90. This PR temporarily handles failures in either `emptyDrops` or `emptyDropsCellRanger` by implementing a hard cutoff for filtering. I am setting a default value for the hard cutoff at a total UMI count of greater than 100. I think this is fairly reasonable, but let me know if others have differing opinions. 

In doing this, I added a parameter for the `umi_cutoff` to the `filter_counts` function which is only invoked in the event of a failure of one of the `DropletUtils` methods. I also added to the metadata of the SCE, the filtering type being used as either `emptyDrops`, `emptyDropsCellRanger`, or `UMI cutoff`. I also added the `umi_cutoff` that was used to the metadata (e.g. 100 as default), in the case of that being the method used. 

For the QC report, I added in a line in the `Cell Statistics` table that has the filtering method that was used. In doing this, I chose to change the line in the `Pre processing information` that previously had `Filtering method` to be `Alevin fry droplet detection`. This refers to using the unfiltered permit list or using a knee method. I was unsure on this name but thought filtering method didn't fit with how we describe it in the docs, since we talk about filtering more in the context of `emptyDrops`. 

I also added a warning statement below that table that if the filtering method is `UMI cutoff` to let the user know that there may be a low number of droplets. Are we okay with this? or would we prefer a different warning message or no message at all? 

Finally, I adjusted the test functions slightly to test the different types of filtering we can do in `filter_counts` and in order to get the test for generating the QC report to pass, I needed to actually perform filtering using `filter_counts` as that adds in the metadata that we now need to access to add into the QC report. 

**Next Steps:**
In response to these changes we will also need to update the documentation and incorporate the filtering type to the `metadata.json` file that is produced as part of `scpca-nf`. If we are okay with this approach then I will go ahead and file those issues. 
I can imagine that we will want to further tweak this, but I think this general approach will solve the problem of failing because of filtering until we can explore this issue further. 

I've included an example of what the new QC report looks like for a sample that is unable to pass filtering and would have to be filtered with a hard cutoff. 
[SCPCL000018_qc_report.html.zip](https://github.com/AlexsLemonade/scpcaTools/files/8036543/SCPCL000018_qc_report.html.zip)
