### PR TITLE
Make Seurat a bit more robust and fail more elegantly

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scpcaTools
 Type: Package
 Title: Single cell data tools for ScPCA
-Version: 0.1.4
+Version: 0.1.5
 Authors@R: c(
     person("Ally", "Hawkins",
            email = "ally.hawkins@ccdatalab.org",

--- a/R/add_cellhash_calls.R
+++ b/R/add_cellhash_calls.R
@@ -123,7 +123,7 @@ add_demux_hashedDrops <- function(sce, altexp_id = "cellhash", ...){
   if(is.null(sample_ids)){
     sample_ids <- rowData(altExp(sce, altexp_id))$barcode_id
   }
-  if (is.null(sample_ids)){
+  if(is.null(sample_ids)){
     warning("No sample ids are present for demux results, using row names")
     sample_ids <- rownames(altExp(sce, altexp_id))
   }
@@ -197,7 +197,7 @@ add_demux_seurat <- function(sce, altexp_id = "cellhash", ...){
   if(is.null(sample_ids)){
     sample_ids <- rowData(altExp(sce, altexp_id))$barcode_id
   }
-  if (is.null(sample_ids)){
+  if(is.null(sample_ids)){
     warning("No sample ids are present for demux results, using row names")
     sample_ids <- rownames(altExp(sce, altexp_id))
   }

--- a/R/add_cellhash_calls.R
+++ b/R/add_cellhash_calls.R
@@ -212,11 +212,11 @@ add_demux_seurat <- function(sce, altexp_id = "cellhash", ...){
   rownames(alt_counts) <- seurat_features
 
   # Seurat will not like zero count cells or HTOs
-  sce_sum <- colSums(sce_counts)
-  alt_sum <- colSums(alt_counts)
-  seurat_cells <- colnames(sce_sum)[sce_sum > 0 & alt_sum > 0]
-  sce_counts <- sce_counts[,sce_sum > 0 & alt_sum > 0]
-  alt_counts <- alt_counts[,sce_sum > 0 & alt_sum > 0]
+  sce_sum <- Matrix::colSums(sce_counts)
+  alt_sum <- Matrix::colSums(alt_counts)
+  seurat_cells <- names(sce_sum)[sce_sum > 0 & alt_sum > 0]
+  sce_counts <- sce_counts[, seurat_cells]
+  alt_counts <- alt_counts[, seurat_cells]
 
 
   # convert to Seurat object (quietly)

--- a/tests/testthat/test-add_cellhash_calls.R
+++ b/tests/testthat/test-add_cellhash_calls.R
@@ -41,18 +41,19 @@ test_that("cellhash functions work", {
   expect_warning(add_cellhash_ids(sce, wrong_table))
 
 
-  hash_sce <- add_demux_hashedDrops(sce_hashtable)
+  hashdrops_sce <- add_demux_hashedDrops(sce_hashtable)
   hash_cols <- c("hashedDrops_sampleid",
                  "hashedDrops_bestsample",
                  "hashedDrops_LogFC",
                  "hashedDrops_Confident") # a subset of the expected columns for the altExp rowData
-  expect_true(all(hash_cols %in% colnames(colData(altExp(hash_sce)))))
-  expect_false(is.null(hash_sce$hashedDrops_sampleid))
+  expect_true(all(hash_cols %in% colnames(colData(altExp(hashdrops_sce)))))
+  expect_false(is.null(hashdrops_sce$hashedDrops_sampleid))
   # check the results are by sample_id
-  expect_true(all(hash_sce$hashedDrops_sampleid[!is.na(hash_sce$hashedDrops_sampleid)] %in% hashsample_table$sample_id))
+  expect_true(all(hashdrops_sce$hashedDrops_sampleid[!is.na(hash_sce$hashedDrops_sampleid)] %in% hashsample_table$sample_id))
+
   # results with no sample table present
-  expect_warning({hash_sce_nosample <- add_demux_hashedDrops(sce)})
-  expect_true(all(hash_sce_nosample$hashedDrops_sampleid[!is.na(hash_sce_nosample$hashedDrops_sampleid)] %in% rownames(altExp(hash_sce_nosample))))
+  expect_warning({hashdrops_sce_nosample <- add_demux_hashedDrops(sce)})
+  expect_true(all(hashdrops_sce_nosample$hashedDrops_sampleid[!is.na(hashdrops_sce_nosample$hashedDrops_sampleid)] %in% rownames(altExp(hashdrops_sce_nosample))))
 
   # test seurat functions
   hto_sce <- add_demux_seurat(sce_hashtable)

--- a/tests/testthat/test-add_cellhash_calls.R
+++ b/tests/testthat/test-add_cellhash_calls.R
@@ -40,7 +40,7 @@ test_that("cellhash functions work", {
                             sample_id = paste0("other", 1:4))
   expect_warning(add_cellhash_ids(sce, wrong_table))
 
-
+  ## test hasheddrops functions
   hashdrops_sce <- add_demux_hashedDrops(sce_hashtable)
   hash_cols <- c("hashedDrops_sampleid",
                  "hashedDrops_bestsample",
@@ -70,5 +70,4 @@ test_that("cellhash functions work", {
   expect_true(all(hto_sce_nosample$hashedDrops_sampleid[!is.na(hto_sce_nosample$hashedDrops_sampleid)] %in% rownames(altExp(hto_sce_nosample))))
 
 })
-
 

--- a/tests/testthat/test-read_alevin.R
+++ b/tests/testthat/test-read_alevin.R
@@ -7,9 +7,11 @@ intron_dir <- file.path(dir, "Breast_Cancer_3p_LT/alevinfry_intron_filtered")
 sce_alevin_size <- c(60275, 10378)
 # expected alevin-fry matrix size
 sce_af_size <- c(60321, 614)
+sample_ids = c("A1", "A2")
 
 test_that("reading salmon alevin data works", {
-  sce <- read_alevin(alevin_dir)
+  sce <- read_alevin(alevin_dir,
+                     sample_id = sample_ids )
   expect_s4_class(sce, "SingleCellExperiment")
   expect_equal(dim(sce), sce_alevin_size)
   # check that column names are barcodes
@@ -19,13 +21,14 @@ test_that("reading salmon alevin data works", {
   expect_false(is.null(sce@metadata$salmon_version))
   expect_false(is.null(sce@metadata$reference_index))
   expect_null(sce@metadata$alevinfry_version)
-
+  expect_equal(sce@metadata$sample_id, sample_ids)
 })
 
 test_that("reading alevin-fry USA mode works", {
   sce <- read_alevin(usa_dir,
                      usa_mode = TRUE,
-                     which_counts = "spliced")
+                     which_counts = "spliced",
+                     sample_id = sample_ids)
   expect_s4_class(sce, "SingleCellExperiment")
   expect_equal(dim(sce), sce_af_size)
   # check that column names are barcodes
@@ -37,6 +40,7 @@ test_that("reading alevin-fry USA mode works", {
   expect_false(is.null(sce@metadata$salmon_version))
   expect_false(is.null(sce@metadata$reference_index))
   expect_false(is.null(sce@metadata$alevinfry_version))
+  expect_equal(sce@metadata$sample_id, sample_ids)
 
   # no remaining unspliced
   unmerged_genes <- str_subset(rownames(sce), "-[IUA]$")
@@ -63,5 +67,4 @@ test_that("reading alevin-fry intron mode works", {
   # no remaining unspliced
   unmerged_genes <- str_subset(rownames(sce), "-[IUA]$")
   expect_length(unmerged_genes, 0)
-
 })


### PR DESCRIPTION
This PR should make calling the Seurat `HTODemux()` function more robust, particularly with unfiltered or loosely filtered data. In particular, it removes cellhash HTOs that are found very rarely  before performing calling, and also removes any lingering cells that might have no reads. I picked a threshold of < 0.1% of cells with counts greater than 1 for a each HTO, which I found in a few real data sets seemed to do a good job of eliminating spurious mappings in the data sets that I was able to play with. I considered using a higher threshold, which might make it even more robust, but I didn't want to get rid of HTOs that might correspond to real but rare cells in the multiplexed set. 

In the event that `HTODemux()` still fails, I still add a column for the results in the main `colData` object, but with `NA` values rather than real results. I don't include any results in the `altExp`.

closes #99 (until the next place Seurat breaks)