### PR TITLE
Handle miQC filtering errors

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,6 +30,7 @@ jobs:
       - name: Install R dependencies
         run: |
           options(repos = c(CRAN = "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"))
+          options(BioC_mirror = "https://packagemanager.rstudio.com/bioconductor")
           install.packages(c("remotes", "rcmdcheck"))
           remotes::install_cran("BiocManager")
           remotes::install_deps(dependencies = TRUE, repos = BiocManager::repositories())

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,7 +30,6 @@ jobs:
       - name: Install R dependencies
         run: |
           options(repos = c(CRAN = "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"))
-          options(BioC_mirror = "https://packagemanager.rstudio.com/bioconductor")
           install.packages(c("remotes", "rcmdcheck"))
           remotes::install_cran("BiocManager")
           remotes::install_deps(dependencies = TRUE, repos = BiocManager::repositories())

--- a/R/add_miQC.R
+++ b/R/add_miQC.R
@@ -52,7 +52,7 @@ add_miQC <- function(sce, posterior_cutoff = 0.75, seed = NULL){
                           posterior_cutoff = posterior_cutoff,
                           verbose = FALSE)
       )
-    })
+    }, silent = TRUE)
   }
 
   if (!is(model, "flexmix") || length(model@components) < 2){

--- a/tests/testthat/test-add_cellhash_calls.R
+++ b/tests/testthat/test-add_cellhash_calls.R
@@ -45,6 +45,7 @@ test_that("adding cellhash ids works", {
 
 test_that("hashedDrops functions work", {
   ## test hasheddrops functions
+  sce_hashtable <- add_cellhash_ids(sce, hashsample_table, altexp_id = "cellhash")
   hashdrops_sce <- add_demux_hashedDrops(sce_hashtable)
   hash_cols <- c("hashedDrops_sampleid",
                  "hashedDrops_bestsample",
@@ -65,6 +66,7 @@ test_that("seurat functions work", {
     skip("The Seurat package was not installed. Skipping tests")
   }
   # test seurat functions
+  sce_hashtable <- add_cellhash_ids(sce, hashsample_table, altexp_id = "cellhash")
   hto_sce <- add_demux_seurat(sce_hashtable)
   hto_cols <- c("HTODemux_maxID",
                 "HTODemux_secondID",


### PR DESCRIPTION
After some debugging, I found that the errors we were getting were occurring when the `miQC` model fitting resulted in two components that were very similar (almost 1 component). The result of this was almost all cells getting probability compromised of ~ 0.5, so they all "pass", which causes trouble for the `enforce_left_cutoff = TRUE` code path. 

![fail_fit](https://user-images.githubusercontent.com/20483/167445429-eb4ea5e4-0cf7-4624-b371-e5698af577ba.png)


So here I am fixing it by checking whether `miQC::filterCells()` works before proceeding much past building the model. If it fails, we try again a couple times before continuing.

I am currently setting `miQC_pass` to NA in the case where we have a model but it failed to filter properly. This is a bit different from the behavior when the model totally failed and we set prob_compromised to NA and leave `miQC_pass` and `miQC_model` off entirely. I almost think I should do the same thing in this case as this really is a kind of model failure, so we might not want to report the bad model at all. Let me know what you think.


closes #101 