### PR TITLE
Add multiplex section to QC report

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Tools for processing single cell data associated with the
 License: BSD_3_clause + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.0
 Depends: 
     R (>= 4.1.0)
 Imports: 

--- a/R/generate_qc_report.R
+++ b/R/generate_qc_report.R
@@ -1,6 +1,6 @@
 #' Generate a QC report from a SingleCellExperiment object
 #'
-#' @param sample_name The name of the sample for report headers
+#' @param library_id The name of the library_id for report headers
 #' @param unfiltered_sce A SingleCellExperiment object that the report will describe
 #' @param filtered_sce An optional filtered single cell experiment derived from first
 #' @param output The output file path that will be created.
@@ -13,10 +13,10 @@
 #'
 #' @examples
 #' \dontrun{
-#' generate_qc_report("Sample 1", my_sce, output = "reports/sample1_report.html")
+#' generate_qc_report("Library 1", my_sce, output = "reports/sample1_report.html")
 #' }
 #'
-generate_qc_report <- function(sample_name,
+generate_qc_report <- function(library_id,
                                unfiltered_sce,
                                filtered_sce = NULL,
                                output = NULL){
@@ -37,7 +37,7 @@ generate_qc_report <- function(sample_name,
   }
 
   if(is.null(output)){
-    output_file = glue::glue("{sample_name}_qc_report")
+    output_file = glue::glue("{library_id}_qc_report")
     output_dir = "."
   } else {
     output_file = basename(output)
@@ -50,7 +50,7 @@ generate_qc_report <- function(sample_name,
     output_file = output_file,
     output_dir = output_dir,
     params = list(
-      sample = sample_name,
+      library = library_id,
       unfiltered_sce = unfiltered_sce,
       filtered_sce = filtered_sce
     ),

--- a/docker/renv.lock
+++ b/docker/renv.lock
@@ -2583,10 +2583,10 @@
     },
     "rlang": {
       "Package": "rlang",
-      "Version": "0.4.12",
+      "Version": "1.0.2",
       "Source": "Repository",
       "Repository": "CRAN",
-      "Hash": "0879f5388fe6e4d56d7ef0b7ccb031e5",
+      "Hash": "04884d9a75d778aca22c7154b8333ec9",
       "Requirements": []
     },
     "rmarkdown": {

--- a/inst/rmd/multiplex_qc.Rmd
+++ b/inst/rmd/multiplex_qc.Rmd
@@ -1,0 +1,81 @@
+# Multiplexing Experiment Summary
+
+## Multiplexing Statistics
+
+```{r}
+# add rowData if missing
+if (is.null(rowData(multiplex_exp)$detected)){
+  multiplex_exp <- scuttle::addPerFeatureQCMetrics(multiplex_exp)
+}
+
+cell_hto_counts <- Matrix::colSums(counts(multiplex_exp))
+
+hto_information <- tibble::tibble(
+  "Number of HTOs assayed" = 
+    format(nrow(multiplex_exp), big.mark = ',', scientific = FALSE),
+  "Multiplex reads sequenced" = 
+    format(multiplex_meta$total_reads, big.mark = ',', scientific = FALSE),
+  "Percent multiplex reads mapped to ADTs" = 
+    paste0(round(multiplex_meta$mapped_reads/multiplex_meta$total_reads * 100, digits = 2), "%"),
+  "Percent of HTOs in cells" = 
+    paste0(round(sum(cell_hto_counts)/multiplex_meta$mapped_reads * 100, digits = 2), "%"),
+  "Percent of cells with HTOs" = 
+    paste0(round(sum(cell_hto_counts > 0)/length(cell_hto_counts) * 100, digits = 2), "%"),
+  "Median HTO UMIs per cell" = 
+    format(median(cell_hto_counts), big.mark = ',', scientific = FALSE)
+  )|>
+  t()
+
+knitr::kable(hto_information, align = 'r') |>
+  kableExtra::kable_styling(bootstrap_options = "striped",
+                            full_width = FALSE,
+                            position = "left") |>
+  kableExtra::column_spec(2, monospace = TRUE)
+```
+
+## Hashtag Oligos (HTOs) Statistics
+
+```{r}
+hto_tags <- as.data.frame(rowData(multiplex_exp)) |>
+  tibble::rownames_to_column("Hashtag Oligo (HTO)") |>
+  arrange(desc(mean)) |>
+  select("Hashtag Oligo (HTO)",
+         "Mean UMI count per cell" = mean,
+         "Percent of cells detected" = detected)
+
+knitr::kable(hto_tags, digits = 2) |>
+  kableExtra::kable_styling(bootstrap_options = c("striped", "condensed"),
+                            full_width = FALSE,
+                            position = "left",
+                            ) |>
+  kableExtra::column_spec(2:3, monospace = TRUE) 
+```
+## Demultiplexing Cell Calls 
+
+Here we use a variety of methods for demultiplexing and assignment of each...  
+
+```{r}
+demux_calls <- data.frame(
+  hashedDrops = filtered_sce$hashedDrops_sampleid,
+  HTODemux = filtered_sce$HTODemux_sampleid,
+  vireo = filtered_sce$vireo_sampleid
+) |>
+  tidyr::pivot_longer(cols = everything(),
+                      names_to = "demux_method",
+                      values_to = "Sample") |>
+  dplyr::count(Sample, demux_method) |>
+  tidyr::pivot_wider(names_from = demux_method,
+                     values_from = n)
+  
+  
+knitr::kable(demux_calls, digits = 2) |>
+  kableExtra::kable_styling(bootstrap_options = c("striped", "condensed"),
+                            full_width = FALSE,
+                            position = "left",
+                            ) |>
+  kableExtra::column_spec(2:3, monospace = TRUE) 
+
+
+```
+
+

--- a/inst/rmd/multiplex_qc.Rmd
+++ b/inst/rmd/multiplex_qc.Rmd
@@ -83,7 +83,7 @@ knitr::kable(demux_calls, digits = 2) |>
                             full_width = FALSE,
                             position = "left",
                             ) |>
-  kableExtra::column_spec(2:3, monospace = TRUE) 
+  kableExtra::column_spec(2:ncol(demux_calls), monospace = TRUE) 
 
 
 ```

--- a/inst/rmd/multiplex_qc.Rmd
+++ b/inst/rmd/multiplex_qc.Rmd
@@ -50,7 +50,8 @@ knitr::kable(hto_tags, digits = 2) |>
                             ) |>
   kableExtra::column_spec(2:3, monospace = TRUE) 
 ```
-## Demultiplexing Cell Calls 
+
+## Demultiplexing Sample Calls 
 
 Demultiplexing was performed using both [DropletUtils::hashedDrops](https://rdrr.io/github/MarioniLab/DropletUtils/man/hashedDrops.html) and [Seurat::HTOdemux](https://rdrr.io/github/satijalab/seurat/man/HTODemux.html) only on the _filtered_ cells, using default parameters for each.
 
@@ -59,32 +60,42 @@ The genetic demultiplexing results are reported under the `vireo` column in the 
 
 **Note:** We have reported the demultiplexed sample calls for each of the above mentioned algorithms, but the multiplexed library has not been separated into individual samples. 
 
-```{r}
+```{r, results='asis'}
 # grab columns that have demuxing results as not all methods could be present
 # e.g. vireo is only used if a matching bulk RNA seq library is there, 
 # otherwise those calls will not be present
 demux_methods <- c("hashedDrops_sampleid", "HTODemux_sampleid", "vireo_sampleid")
 demux_columns <- colnames(colData(filtered_sce)) %in% demux_methods
 
-# create a table summarizing demuxing calls for each method used 
-demux_calls <- as.data.frame(colData(filtered_sce)[, demux_columns]) |>
-  # remove _sampleid at the end of the column names
-  dplyr::rename_with(~stringr::str_remove(., "_sampleid")) |>
-  tidyr::pivot_longer(cols = everything(),
-                      names_to = "demux_method",
-                      values_to = "Sample") |>
-  dplyr::count(Sample, demux_method) |>
-  tidyr::pivot_wider(names_from = demux_method,
-                     values_from = n)
+if(any(demux_columns)){
+ # create a table summarizing demuxing calls for each method used 
+  demux_calls <- as.data.frame(colData(filtered_sce)[, demux_columns]) |>
+    # remove _sampleid at the end of the column names
+    dplyr::rename_with(~stringr::str_remove(., "_sampleid")) |>
+    tidyr::pivot_longer(cols = everything(),
+                        names_to = "demux_method",
+                        values_to = "Sample") |>
+    dplyr::count(Sample, demux_method) |>
+    tidyr::pivot_wider(names_from = demux_method,
+                       values_from = n)
   
   
-knitr::kable(demux_calls, digits = 2) |>
-  kableExtra::kable_styling(bootstrap_options = c("striped", "condensed"),
-                            full_width = FALSE,
-                            position = "left",
-                            ) |>
-  kableExtra::column_spec(2:ncol(demux_calls), monospace = TRUE) 
-
+  knitr::kable(demux_calls, digits = 2) |>
+    kableExtra::kable_styling(bootstrap_options = c("striped", "condensed"),
+                              full_width = FALSE,
+                              position = "left",
+    ) |>
+    kableExtra::column_spec(2:ncol(demux_calls), monospace = TRUE)  
+}else{
+  glue::glue("
+    <div class=\"alert alert-warning\">
+    
+    Demultiplexing was not applied to this library using any of the above mentioned methods.
+    Sample calls cannot be reported.
+    
+    </div>
+  ")
+}
 
 ```
 

--- a/inst/rmd/multiplex_qc.Rmd
+++ b/inst/rmd/multiplex_qc.Rmd
@@ -88,7 +88,7 @@ if(any(demux_columns)){
     kableExtra::column_spec(2:ncol(demux_calls), monospace = TRUE)  
 }else{
   glue::glue("
-    <div class=\"alert alert-warning\">
+    <div class=\"alert alert-info\">
     
     Demultiplexing was not applied to this library using any of the above mentioned methods.
     Sample calls cannot be reported.

--- a/inst/rmd/multiplex_qc.Rmd
+++ b/inst/rmd/multiplex_qc.Rmd
@@ -52,14 +52,24 @@ knitr::kable(hto_tags, digits = 2) |>
 ```
 ## Demultiplexing Cell Calls 
 
-Here we use a variety of methods for demultiplexing and assignment of each...  
+Demultiplexing was performed using both [DropletUtils::hashedDrops](https://rdrr.io/github/MarioniLab/DropletUtils/man/hashedDrops.html) and [Seurat::HTOdemux](https://rdrr.io/github/satijalab/seurat/man/HTODemux.html) only on the _filtered_ cells, using default parameters for each.
+
+For multiplex libraries where bulk RNA-seq data is available for the individual samples, we also performed demultiplexing analysis using genotype data following the methods described in [Weber _et al._ (2021)](https://doi.org/10.1093/gigascience/giab062). 
+The genetic demultiplexing results are reported under the `vireo` column in the below table.   
+
+:warning: We have reported the demultiplexed sample calls for each of the above mentioned algorithms, but the multiplexed library has not been separated into individual samples. 
 
 ```{r}
-demux_calls <- data.frame(
-  hashedDrops = filtered_sce$hashedDrops_sampleid,
-  HTODemux = filtered_sce$HTODemux_sampleid,
-  vireo = filtered_sce$vireo_sampleid
-) |>
+# grab columns that have demuxing results as not all methods could be present
+# e.g. vireo is only used if a matching bulk RNA seq library is there, 
+# otherwise those calls will not be present
+demux_methods <- c("hashedDrops_sampleid", "HTODemux_sampleid", "vireo_sampleid")
+demux_columns <- colnames(colData(filtered_sce)) %in% demux_methods
+
+# create a table summarizing demuxing calls for each method used 
+demux_calls <- as.data.frame(colData(filtered_sce)[, demux_columns]) |>
+  # remove _sampleid at the end of the column names
+  dplyr::rename_with(~stringr::str_remove(., "_sampleid")) |>
   tidyr::pivot_longer(cols = everything(),
                       names_to = "demux_method",
                       values_to = "Sample") |>

--- a/inst/rmd/multiplex_qc.Rmd
+++ b/inst/rmd/multiplex_qc.Rmd
@@ -57,7 +57,7 @@ Demultiplexing was performed using both [DropletUtils::hashedDrops](https://rdrr
 For multiplex libraries where bulk RNA-seq data is available for the individual samples, we also performed demultiplexing analysis using genotype data following the methods described in [Weber _et al._ (2021)](https://doi.org/10.1093/gigascience/giab062). 
 The genetic demultiplexing results are reported under the `vireo` column in the below table.   
 
-:warning: We have reported the demultiplexed sample calls for each of the above mentioned algorithms, but the multiplexed library has not been separated into individual samples. 
+**Note:** We have reported the demultiplexed sample calls for each of the above mentioned algorithms, but the multiplexed library has not been separated into individual samples. 
 
 ```{r}
 # grab columns that have demuxing results as not all methods could be present

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -1,11 +1,11 @@
 ---
 params:
-  sample: Example
+  library: Example
   unfiltered_sce: !r scpcaTools:::sim_sce()
   filtered_sce: NULL
   date: !r Sys.Date()
 
-title: "`r glue::glue('ScPCA QC report for {params$sample}')`"
+title: "`r glue::glue('ScPCA QC report for {params$library}')`"
 author: "Childhood Cancer Data Lab"
 date: "`r params$date`"
 output: 
@@ -35,17 +35,24 @@ theme_set(theme_bw() +
 
 ```{r sce_setup}
 # save some typing later
-sample_id <- params$sample
+library_id <- params$library
 unfiltered_sce <- params$unfiltered_sce
 filtered_sce <- params$filtered_sce
 
 has_filtered <- !is.null(filtered_sce)
 
+# grab sample id from filtered sce, if missing use library id for both
+if(is.null(metadata(filtered_sce)$sample_id)){
+  sample_id <- library_id
+} else {
+  sample_id <- metadata(filtered_sce)$sample_id
+}
 
 # if there is no filtered sce, use the unfiltered for both
 if (!has_filtered){
   filtered_sce <- unfiltered_sce
 }
+
 # add cell stats if missing
 if (is.null(unfiltered_sce$sum)){
   unfiltered_sce <- scuttle::addPerCellQCMetrics(unfiltered_sce)
@@ -76,11 +83,12 @@ if (has_cite){
 has_multiplex <- "cellhash" %in% altExpNames(filtered_sce)
 if(has_multiplex){
   modalities <- c(modalities, "Multiplex")
-  multiplex_samples <- paste(metadata(filtered_sce)$sample_id, collapse = ", ")
+  # convert sample ID to bullet separated list 
+  multiplex_samples <- paste0("<li>", paste(sample_id, collapse = '</li><li>', "</li>"))
 }
 ```
 
-# Processing Information for `r sample_id`
+# Processing Information for `r library_id`
 
 ```{r, results='asis'}
 if(has_multiplex){
@@ -88,12 +96,14 @@ if(has_multiplex){
     <div class=\"alert alert-warning\">
     
     This library is multiplexed and contains data from more than one sample.  
-    Data from the following samples are included in this library: 
+    Data from the following samples are included in this library:
+    
     {multiplex_samples}
     
     </div>
   ")
 }
+
 ```
 
 ## Raw Sample Metrics
@@ -103,7 +113,8 @@ if(has_multiplex){
 unfiltered_meta <- metadata(unfiltered_sce) 
 
 sample_information <- tibble::tibble(
-  "Sample id" = sample_id,
+  "Library id" = library_id,
+  "Sample id" = paste(sample_id, collapse = ", "),
   "Tech version" = format(unfiltered_meta$tech_version), # format to keep nulls
   "Data modalities" = paste(modalities, collapse = ", "),
   "Cells reported by alevin-fry" = 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -72,9 +72,29 @@ has_cite <- "CITEseq" %in% altExpNames(filtered_sce)
 if (has_cite){
   modalities <- c(modalities, "CITE-seq")
 }
+
+has_multiplex <- "cellhash" %in% altExpNames(filtered_sce)
+if(has_multiplex){
+  modalities <- c(modalities, "Multiplex")
+  multiplex_samples <- paste(metadata(filtered_sce)$sample_id, collapse = ", ")
+}
 ```
 
 # Processing Information for `r sample_id`
+
+```{r, results='asis'}
+if(has_multiplex){
+  glue::glue("
+    <div class=\"alert alert-warning\">
+    
+    This library is multiplexed and contains data from more than one sample.  
+    Data from the following samples are included in this library: 
+    {multiplex_samples}
+    
+    </div>
+  ")
+}
+```
 
 ## Raw Sample Metrics
 
@@ -109,6 +129,21 @@ if (has_cite){
         paste0(round(cite_meta$mapped_reads/cite_meta$total_reads * 100, digits = 2), "%")
     )
 }
+if (has_multiplex){
+  multiplex_exp <- altExp(filtered_sce, "cellhash")
+  multiplex_meta <- metadata(multiplex_exp)
+  
+  sample_information <- sample_information |>
+    mutate(
+      "Number of HTOs assayed" = 
+        format(nrow(multiplex_exp), big.mark = ',', scientific = FALSE),
+      "Multiplex reads sequenced" = 
+        format(multiplex_meta$total_reads, big.mark = ',', scientific = FALSE),
+      "Percent of multiplex reads mapped to HTOs" = 
+        paste0(round(multiplex_meta$mapped_reads/multiplex_meta$total_reads * 100, digits = 2), "%")
+    )
+}
+
 
 sample_information <- sample_information |>
   mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) |> # reformat nulls
@@ -308,6 +343,11 @@ In such situations, the calculated probability of compromise may not be valid (s
 
 <!-- Next section included only if CITE-seq data is present -->
 ```{r, child='cite_qc.rmd', eval = has_cite}
+```
+
+<!-- Next section only included if multiplex data is present --> 
+```{r, child='multiplex_qc.rmd', eval = has_multiplex}
+
 ```
 
 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -43,9 +43,9 @@ has_filtered <- !is.null(filtered_sce)
 
 # grab sample id from filtered sce, if missing set sample ID to NA
 if(is.null(metadata(filtered_sce)$sample_id)){
-  sample_id <- library_id
-} else {
   sample_id <- NA
+} else {
+  sample_id <- metadata(filtered_sce)$sample_id
 }
 
 # if there is no filtered sce, use the unfiltered for both

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -41,11 +41,11 @@ filtered_sce <- params$filtered_sce
 
 has_filtered <- !is.null(filtered_sce)
 
-# grab sample id from filtered sce, if missing use library id for both
+# grab sample id from filtered sce, if missing set sample ID to NA
 if(is.null(metadata(filtered_sce)$sample_id)){
   sample_id <- library_id
 } else {
-  sample_id <- metadata(filtered_sce)$sample_id
+  sample_id <- NA
 }
 
 # if there is no filtered sce, use the unfiltered for both

--- a/man/generate_qc_report.Rd
+++ b/man/generate_qc_report.Rd
@@ -5,14 +5,14 @@
 \title{Generate a QC report from a SingleCellExperiment object}
 \usage{
 generate_qc_report(
-  sample_name,
+  library_id,
   unfiltered_sce,
   filtered_sce = NULL,
   output = NULL
 )
 }
 \arguments{
-\item{sample_name}{The name of the sample for report headers}
+\item{library_id}{The name of the library_id for report headers}
 
 \item{unfiltered_sce}{A SingleCellExperiment object that the report will describe}
 
@@ -30,7 +30,7 @@ Generate a QC report from a SingleCellExperiment object
 }
 \examples{
 \dontrun{
-generate_qc_report("Sample 1", my_sce, output = "reports/sample1_report.html")
+generate_qc_report("Library 1", my_sce, output = "reports/sample1_report.html")
 }
 
 }

--- a/tests/testthat/test-generate_qc_report.R
+++ b/tests/testthat/test-generate_qc_report.R
@@ -3,7 +3,7 @@ sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 10)
 filt_sce <- filter_counts(sce)
 
 test_that("generating a qc report works", {
-  qc_file <- generate_qc_report(sample_name = "TEST",
+  qc_file <- generate_qc_report(library_id = "TEST",
                                 unfiltered_sce = sce,
                                 filtered_sce = filt_sce, )
   expect_true(file.exists(qc_file))


### PR DESCRIPTION
Related to https://github.com/AlexsLemonade/scpca-nf/issues/173, this PR adds information related to multiplexed libraries to the QC report. I've gone ahead and added the following: 

- A warning at the beginning of the report stating that the library is multiplexed and contains data for multiple samples. I also included all multiplexed samples that can be found in the library. One thing I thought of that would be helpful is adding a link to the docs for what is a multiplexed sample, but we don't actually have that link yet. 
- `Multiplex` to the list of modalities in the `Raw Sample Metrics` table 
- Some general stats of the HTO library to the `Raw Sample Metrics`, mirroring what was present for CITE-seq 
- A multiplex child report with similar tables to what was present for the CITE-seq libraries that summarizes some information about the HTO's such as total reads and % reads mapped to HTOs. I also added a table with each HTO and then the mean UMI per cell and percent of cells detected (taking the `rowData` from the `altExp`). 
- The last table that I added to the QC report was the multiplexing sample calls that includes a summary of calls for each sample across each method, including the total `NA` for each method. 

For the most part I mirrored what was present in the CITE-seq QC reports, but let me know if you think anything is either missing or maybe should not be reported on the report. 
Also do we want to include any further information besides just the table of sample calls for the demultiplexing? The only other thing that I think could _maybe_ be relevant are the UMAPs coloring by sample id for each method, but wasn't quite sure that was necessary to go that deep. 

I've also included an example of the rendered report for reference when reviewing.
[SCPCL000533_qc_report.html.zip](https://github.com/AlexsLemonade/scpcaTools/files/8766289/SCPCL000533_qc_report.html.zip)
 