### PR TITLE
Change filename used for child multiplex QC report

### DIFF
--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -357,7 +357,7 @@ In such situations, the calculated probability of compromise may not be valid (s
 ```
 
 <!-- Next section only included if multiplex data is present --> 
-```{r, child='multiplex_qc.rmd', eval = has_multiplex}
+```{r, child='multiplex_qc.Rmd', eval = has_multiplex}
 
 ```
 


### PR DESCRIPTION
In testing the latest changes in `scpca-nf`, I ran into an error where the filename had an extension of `.Rmd` rather than `.rmd` so it couldn't find the child template notebook to add in. I tried to change the filename, rather than change it to use `.Rmd`, but github wasn't noticing that as a change and letting me commit that... So here I'm updating the name of the template report. 

Here's a screenshot of the error I received: 
<img width="1149" alt="Screen Shot 2022-06-02 at 4 09 01 PM" src="https://user-images.githubusercontent.com/54039191/171738680-00f42721-5db2-4678-a2ac-60219e3b9e9b.png">

