### PR TITLE
Remove warning for multiplexed samples with only one HTO 

### DIFF
--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -81,7 +81,7 @@ if (has_cite){
 }
 
 # only print out multiplexed warning if more than one sample is present
-has_multiplex = if (length(sample_id) > 1){TRUE} else {FALSE}
+has_multiplex <- length(sample_id) > 1
 if(has_multiplex){
   # convert sample ID to bullet separated list 
   multiplex_samples <- paste0("<li>", paste(sample_id, collapse = '</li><li>', "</li>"))

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -80,11 +80,17 @@ if (has_cite){
   modalities <- c(modalities, "CITE-seq")
 }
 
-has_multiplex <- "cellhash" %in% altExpNames(filtered_sce)
+# only print out multiplexed warning if more than one sample is present
+has_multiplex = if (length(sample_ids) > 1){TRUE} else {FALSE}
 if(has_multiplex){
-  modalities <- c(modalities, "Multiplex")
   # convert sample ID to bullet separated list 
   multiplex_samples <- paste0("<li>", paste(sample_id, collapse = '</li><li>', "</li>"))
+}
+
+# check for cellhash to add to list of modalities
+has_cellhash <- "cellhash" %in% altExpNames(filtered_sce)
+if(has_cellhash){
+  modalities <- c(modalities, "Multiplex")
 }
 ```
 
@@ -357,7 +363,7 @@ In such situations, the calculated probability of compromise may not be valid (s
 ```
 
 <!-- Next section only included if multiplex data is present --> 
-```{r, child='multiplex_qc.rmd', eval = has_multiplex}
+```{r, child='multiplex_qc.rmd', eval = has_cellhash}
 
 ```
 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -80,13 +80,6 @@ if (has_cite){
   modalities <- c(modalities, "CITE-seq")
 }
 
-# only print out multiplexed warning if more than one sample is present
-has_multiplex <- length(sample_id) > 1
-if(has_multiplex){
-  # convert sample ID to bullet separated list 
-  multiplex_samples <- paste0("<li>", paste(sample_id, collapse = '</li><li>', "</li>"))
-}
-
 # check for cellhash to add to list of modalities
 has_cellhash <- "cellhash" %in% altExpNames(filtered_sce)
 if(has_cellhash){
@@ -97,7 +90,12 @@ if(has_cellhash){
 # Processing Information for `r library_id`
 
 ```{r, results='asis'}
+# only print out multiplexed warning if more than one sample is present
+has_multiplex <- length(sample_id) > 1
+
 if(has_multiplex){
+  # convert sample ID to bullet separated list 
+  multiplex_samples <- paste0("<li>", paste(sample_id, collapse = '</li><li>', "</li>"))
   glue::glue("
     <div class=\"alert alert-warning\">
     

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -81,7 +81,7 @@ if (has_cite){
 }
 
 # only print out multiplexed warning if more than one sample is present
-has_multiplex = if (length(sample_ids) > 1){TRUE} else {FALSE}
+has_multiplex = if (length(sample_id) > 1){TRUE} else {FALSE}
 if(has_multiplex){
   # convert sample ID to bullet separated list 
   multiplex_samples <- paste0("<li>", paste(sample_id, collapse = '</li><li>', "</li>"))
@@ -146,7 +146,7 @@ if (has_cite){
         paste0(round(cite_meta$mapped_reads/cite_meta$total_reads * 100, digits = 2), "%")
     )
 }
-if (has_multiplex){
+if (has_cellhash){
   multiplex_exp <- altExp(filtered_sce, "cellhash")
   multiplex_meta <- metadata(multiplex_exp)
   


### PR DESCRIPTION
In running the multiplexed samples, there was one library that contains cellhashing data, but only has one HTO and only one sample. Because this only contains one sample, we plan on skipping demultiplexing alltogether (otherwise Seurat will fail). Additionally, because this only has one sample, when creating the `metadata.json` file as part of `scpca-nf` the `has_multiplex` flag will get reported as false because it does not have more than one sample (the changes to skip demultiplexing will get filed as a separate PR in `scpca-nf`). It would be confusing to have it be false in the metadata file and then have a warning produced here that said "This library is multiplexed and contains data from more than one sample." However, because this sample still has cellhashing data, it would be helpful to report those statistics. 

I have gone ahead and separated out the check for if there is cell hashing data present in the object and then the check for if the data is multiplexed (i.e. has more than one sample). If the library has more than one sample then the warning will get printed, otherwise it will get skipped. The rest of the report remains the same. 

I attached a copy of the updated report for this specific library.
[SCPCL000533_qc_report.html.zip](https://github.com/AlexsLemonade/scpcaTools/files/8855500/SCPCL000533_qc_report.html.zip)
 