### PR TITLE
Change warning for miQC removal to message

### DIFF
--- a/R/sce_to_anndata.R
+++ b/R/sce_to_anndata.R
@@ -5,6 +5,9 @@
 #' @param anndata_file Path to output AnnData file. Must be an `.h5` or `.hdf5`
 #'
 #' @return original SingleCellExperiment object used as input (invisibly)
+#' **Note that any columns present in the `rowData` of an SCE object that contains
+# duplicated information, e.g. duplicate gene identifiers, are converted to
+# categorical data by the `anndata` package.
 #'
 #' @import SingleCellExperiment
 #'
@@ -36,7 +39,7 @@ sce_to_anndata <- function(sce, anndata_file){
   # remove miQC model from metadata
   if(!is.null(metadata(sce_to_convert)$miQC_model)){
     metadata(sce_to_convert)$miQC_model <- NULL
-    warning("miQC model cannot be converted between SCE and AnnData.")
+    message("miQC model cannot be converted between SCE and AnnData.")
   }
 
   # export SCE object as AnnData to HDF5 file

--- a/R/sce_to_anndata.R
+++ b/R/sce_to_anndata.R
@@ -6,8 +6,8 @@
 #'
 #' @return original SingleCellExperiment object used as input (invisibly)
 #' **Note that any columns present in the `rowData` of an SCE object that contains
-# duplicated information, e.g. duplicate gene identifiers, are converted to
-# categorical data by the `anndata` package.
+#' duplicated information, e.g. duplicate gene identifiers, are converted to
+#' categorical data by the `anndata` package.
 #'
 #' @import SingleCellExperiment
 #'

--- a/R/sce_to_seurat.R
+++ b/R/sce_to_seurat.R
@@ -26,7 +26,7 @@ sce_to_seurat <- function(sce){
   # remove miQC model from metadata
   if(!is.null(metadata(sce)$miQC_model)){
     metadata(sce)$miQC_model <- NULL
-    warning("miQC model will not be included in Seurat object.")
+    message("miQC model will not be included in Seurat object.")
   }
 
 

--- a/man/sce_to_anndata.Rd
+++ b/man/sce_to_anndata.Rd
@@ -13,6 +13,7 @@ sce_to_anndata(sce, anndata_file)
 }
 \value{
 original SingleCellExperiment object used as input (invisibly)
+**Note that any columns present in the `rowData` of an SCE object that contains
 }
 \description{
 Convert SingleCellExperiment objects to AnnData file stored as HDF5 file


### PR DESCRIPTION
Closes #118 and #119. 

This just has a few small changes. The first is changing the previous warning messages when miQC was removed to be just a message. I also added a small note in the documentation for the SCE to AnnData function about the conversion of rowData to categorical data that was discovered when applying the function in data integration. 