### PR TITLE
Update `sce_to_seurat` function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,11 @@ Authors@R: c(
     person(c("Joshua", "A."), "Shapiro", 
            email = "josh.shapiro@ccdatalab.org",
            comment = list(ORCID = "0000-0002-6224-0347"),
-           role = c("aut"))
+           role = c("aut")),
+    person(c("Stephanie", "J."), "Spielman", 
+           email = "stephanie.spielman@ccdatalab.org",
+           comment = list(ORCID = "0000-0002-9090-4788"),
+           role = c("aut"))           
     )
 Maintainer: Ally Hawkins <ally.hawkins@ccdatalab.org>
 Description: Tools for processing single cell data associated with the 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Description: Tools for processing single cell data associated with the
 License: BSD_3_clause + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 Depends: 
     R (>= 4.1.0)
 Imports: 

--- a/R/sce_to_seurat.R
+++ b/R/sce_to_seurat.R
@@ -3,7 +3,9 @@
 #'
 #' @param sce SingleCellExperiment object
 #' @param assay_name The assay name (default "counts") to include in
-#'   the Seurat object
+#'   the Seurat object. This name will be applied as the assay name in
+#'   the Seurat object. If the default "count" assay is used, then the
+#'   assay name will instead be "RNA".
 #'
 #' @return Seurat object
 #'
@@ -51,12 +53,13 @@ sce_to_seurat <- function(sce,
   rowdata <- as.data.frame(rowData(sce))
 
 
-  # create seurat object
+  # create seurat object, with new assay name
   seurat_obj <- Seurat::CreateSeuratObject(counts = sce_counts,
-                                           meta.data = coldata)
+                                           meta.data = coldata,
+                                           assay = assay_name)
 
   # add rowdata and metadata separately adding it while creating leaves the slots empty without warning
-  seurat_obj[["RNA"]]@var.features <- rowdata
+  seurat_obj[[assay_name]]@var.features <- rowdata
   seurat_obj@misc <- metadata(sce)
 
   # grab names of altExp, if any

--- a/R/sce_to_seurat.R
+++ b/R/sce_to_seurat.R
@@ -54,6 +54,10 @@ sce_to_seurat <- function(sce,
 
 
   # create seurat object, with new assay name
+  # use "RNA" as assay name if `counts` is being used from SCE
+  if (assay_name == "counts") {
+    assay_name <- "RNA"
+  }
   seurat_obj <- Seurat::CreateSeuratObject(counts = sce_counts,
                                            meta.data = coldata,
                                            assay = assay_name)

--- a/R/sce_to_seurat.R
+++ b/R/sce_to_seurat.R
@@ -2,6 +2,8 @@
 #' Convert SingleCellExperiment object to Seurat object
 #'
 #' @param sce SingleCellExperiment object
+#' @param assay_name The assay name (default "counts") to include in
+#'   the Seurat object
 #'
 #' @return Seurat object
 #'
@@ -13,7 +15,8 @@
 #' \dontrun{
 #' sce_to_seurat(sce = sce_object)
 #' }
-sce_to_seurat <- function(sce){
+sce_to_seurat <- function(sce,
+                          assay_name = "counts") {
 
   if (!requireNamespace("Seurat", quietly = TRUE)) {
     stop("The Seurat package must be installed to create a Seurat object. No output returned.")
@@ -21,6 +24,10 @@ sce_to_seurat <- function(sce){
 
   if(!is(sce,"SingleCellExperiment")){
     stop("Input must be a SingleCellExperiment object.")
+  }
+
+  if (!assay_name %in% assayNames(sce)) {
+    stop("Provided assay name is not present in the SingleCellExperiment object.")
   }
 
   # remove miQC model from metadata
@@ -31,7 +38,8 @@ sce_to_seurat <- function(sce){
 
 
   # Seurat counts need to be integers
-  sce_counts <- round(counts(sce))
+  # extract the given `assay_name`
+  sce_counts <- round(assay(sce, assay_name))
 
   # Seurat will not like zero count calls
   sce_sum <- Matrix::colSums(sce_counts)

--- a/man/sce_to_anndata.Rd
+++ b/man/sce_to_anndata.Rd
@@ -14,6 +14,8 @@ sce_to_anndata(sce, anndata_file)
 \value{
 original SingleCellExperiment object used as input (invisibly)
 **Note that any columns present in the `rowData` of an SCE object that contains
+duplicated information, e.g. duplicate gene identifiers, are converted to
+categorical data by the `anndata` package.
 }
 \description{
 Convert SingleCellExperiment objects to AnnData file stored as HDF5 file

--- a/man/sce_to_seurat.Rd
+++ b/man/sce_to_seurat.Rd
@@ -4,10 +4,13 @@
 \alias{sce_to_seurat}
 \title{Convert SingleCellExperiment object to Seurat object}
 \usage{
-sce_to_seurat(sce)
+sce_to_seurat(sce, assay_name = "counts")
 }
 \arguments{
 \item{sce}{SingleCellExperiment object}
+
+\item{assay_name}{The assay name (default "counts") to include in
+the Seurat object}
 }
 \value{
 Seurat object

--- a/tests/testthat/.gitignore
+++ b/tests/testthat/.gitignore
@@ -1,0 +1,3 @@
+_snaps/
+test_anndata.h5
+

--- a/tests/testthat/test-sce_to_seurat.R
+++ b/tests/testthat/test-sce_to_seurat.R
@@ -20,6 +20,8 @@ rowData(altExp(sce, alt_name)) <- data.frame("alt_test_row" = sample(0:5, 10, re
   tibble::column_to_rownames("alt_id") %>%
   DataFrame()
 
+logcounts(sce) <- counts(sce) # dummy logcounts to test the assay_name argument
+
 test_that("Converting SCE to Seurat objects works as expected", {
 
   seurat_object <- sce_to_seurat(sce)
@@ -34,7 +36,32 @@ test_that("Converting SCE to Seurat objects works as expected", {
 
   # can't directly check that coldata is equal because of added columns in seurat object
   expect_true(all(colnames(coldata_sce) %in% colnames(seurat_object@meta.data)))
-  expect_equal(rowdata_sce, seurat_object[["RNA"]]@var.features)
+  expect_equal(rowdata_sce, seurat_object[["RNA"]]@var.features) # since default "counts" is used, RNA name is expected here
+  expect_equal(metadata(sce), seurat_object@misc)
+
+  # check that altExp data was converted and rowData
+  expect_s4_class(seurat_object[[alt_name]], 'Assay')
+  alt_rowdata_sce <- as.data.frame(rowData(altExp(sce, alt_name)))
+  expect_equal(alt_rowdata_sce, seurat_object[[alt_name]]@var.features)
+
+})
+
+
+test_that("Converting SCE to Seurat objects works as expected for custom assay name", {
+
+  seurat_object <- sce_to_seurat(sce, assay_name = "logcounts")
+
+  # check that column names of Seurat object are derived from SCE object
+  # they won't necessarily be equal if some cells with 0 counts were removed
+  expect_true(all(colnames(seurat_object) %in% colnames(sce)))
+
+  # check that attached metadata/coldata/rowdata in SCE are present in seurat object
+  coldata_sce <- as.data.frame(colData(sce))
+  rowdata_sce <- as.data.frame(rowData(sce))
+
+  # can't directly check that coldata is equal because of added columns in seurat object
+  expect_true(all(colnames(coldata_sce) %in% colnames(seurat_object@meta.data)))
+  expect_equal(rowdata_sce, seurat_object[["logcounts"]]@var.features) # since default "counts" is used, RNA name is expected here
   expect_equal(metadata(sce), seurat_object@misc)
 
   # check that altExp data was converted and rowData

--- a/tests/testthat/test-sce_to_seurat.R
+++ b/tests/testthat/test-sce_to_seurat.R
@@ -29,7 +29,7 @@ test_that("Converting SCE to Seurat objects works as expected", {
   # check that column names of Seurat object are derived from SCE object
   # they won't necessarily be equal if some cells with 0 counts were removed
   expect_true(all(colnames(seurat_object) %in% colnames(sce)))
-  expect_true("RNA" %in% seurat_object@assays)
+  expect_true("RNA" %in% names(seurat_object@assays))
 
   # check that attached metadata/coldata/rowdata in SCE are present in seurat object
   coldata_sce <- as.data.frame(colData(sce))
@@ -55,7 +55,7 @@ test_that("Converting SCE to Seurat objects works as expected for a non-default 
   # check that column names of Seurat object are derived from SCE object
   # they won't necessarily be equal if some cells with 0 counts were removed
   expect_true(all(colnames(seurat_object) %in% colnames(sce)))
-  expect_true("logcounts" %in% seurat_object@assays)
+  expect_true("logcounts" %in% names(seurat_object@assays))
 
   # check that attached metadata/coldata/rowdata in SCE are present in seurat object
   coldata_sce <- as.data.frame(colData(sce))

--- a/tests/testthat/test-sce_to_seurat.R
+++ b/tests/testthat/test-sce_to_seurat.R
@@ -54,6 +54,7 @@ test_that("Converting SCE to Seurat objects works as expected for a non-default 
   # check that column names of Seurat object are derived from SCE object
   # they won't necessarily be equal if some cells with 0 counts were removed
   expect_true(all(colnames(seurat_object) %in% colnames(sce)))
+  expect_true("logcounts" %in% seurat_object@assays)
 
   # check that attached metadata/coldata/rowdata in SCE are present in seurat object
   coldata_sce <- as.data.frame(colData(sce))

--- a/tests/testthat/test-sce_to_seurat.R
+++ b/tests/testthat/test-sce_to_seurat.R
@@ -29,6 +29,7 @@ test_that("Converting SCE to Seurat objects works as expected", {
   # check that column names of Seurat object are derived from SCE object
   # they won't necessarily be equal if some cells with 0 counts were removed
   expect_true(all(colnames(seurat_object) %in% colnames(sce)))
+  expect_true("RNA" %in% seurat_object@assays)
 
   # check that attached metadata/coldata/rowdata in SCE are present in seurat object
   coldata_sce <- as.data.frame(colData(sce))

--- a/tests/testthat/test-sce_to_seurat.R
+++ b/tests/testthat/test-sce_to_seurat.R
@@ -47,7 +47,7 @@ test_that("Converting SCE to Seurat objects works as expected", {
 })
 
 
-test_that("Converting SCE to Seurat objects works as expected for custom assay name", {
+test_that("Converting SCE to Seurat objects works as expected for a non-default assay of 'logcounts'", {
 
   seurat_object <- sce_to_seurat(sce, assay_name = "logcounts")
 
@@ -61,7 +61,7 @@ test_that("Converting SCE to Seurat objects works as expected for custom assay n
 
   # can't directly check that coldata is equal because of added columns in seurat object
   expect_true(all(colnames(coldata_sce) %in% colnames(seurat_object@meta.data)))
-  expect_equal(rowdata_sce, seurat_object[["logcounts"]]@var.features) # since default "counts" is used, RNA name is expected here
+  expect_equal(rowdata_sce, seurat_object[["logcounts"]]@var.features)
   expect_equal(metadata(sce), seurat_object@misc)
 
   # check that altExp data was converted and rowData


### PR DESCRIPTION
This PR addresses certain aspects of this conversation about data integration: https://github.com/AlexsLemonade/sc-data-integration/issues/123 

We would like to make the `sce_to_seurat()` more flexible in which assay is chosen to include in the new Seurat object. This PR adds an argument `assay_name`, default "counts", which can be specified for this purpose. I also included a check to make sure the assay exists.

All tests are passing, but I did not write more tests for different assay names (but I can if requested!), but the code I wrote indeed still works fine for a "counts" assay as the passing tests reflect! 

I also thought about whether I should update here as well and supply an argument `assay = assay_name`, but the default that is used here by Seurat is "RNA" which is generally expected, so I decided to leave it alone. https://github.com/AlexsLemonade/scpcaTools/blob/a822885e536e31a5dedeb4bacfa52f5aa16ed647/R/sce_to_seurat.R#L47-L51

Finally, I also reran `devtools::document()`, and in addition to the expected man pages update for this function, the `sce_to_anndata` man was updated, and the roxygen note in DESCRIPTION was bumped. I wonder if the docs were just out of date?

Finally #2, should I add myself to `DESCRIPTION` author field? This is a pretty small update so not sure where this change lands!