### PR TITLE
Plot removal of low quality cells in QC report

### DIFF
--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -397,10 +397,12 @@ The dotted vertical line indicates the minimum gene cutoff used for filtering.
 ```{r}
 if(has_filtered & has_processed){
   
+  # grab cutoffs and filtering method from processed sce
   min_gene_cutoff <- processed_meta$min_gene_cutoff
   prob_compromised_cutoff <- processed_meta$prob_compromised_cutoff
   filter_method <- processed_meta$ccdl_filter_method
   
+  # add column to coldata labeling cells to keep/remove based on filtering method
   if(filter_method == "miQC"){
     
     filtered_coldata_df <- filtered_coldata_df %>%

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -403,30 +403,21 @@ if(has_filtered & has_processed){
   filter_method <- processed_meta$ccdl_filter_method
   
   # add column to coldata labeling cells to keep/remove based on filtering method
-  if(filter_method == "miQC"){
+  filtered_coldata_df <- colData(filtered_sce) |>
+    as.data.frame()
     
-    filtered_coldata_df <- filtered_coldata_df %>%
-      dplyr::mutate(ccdl_filter = ifelse(prob_compromised <= prob_compromised_cutoff & 
-                                           detected >= min_gene_cutoff, 
-                                         "Keep", 
-                                         "Remove"))
-    
-  } else if(filter_method == "Minimum_gene_cutoff") {
-    
-    filtered_coldata_df <- filtered_coldata_df %>%
-      dplyr::mutate(ccdl_filter = ifelse(detected >= min_gene_cutoff, 
-                                         "Keep", 
-                                         "Remove"))
-    
-  }
+  filtered_coldata_df <- filtered_coldata_df |>
+    dplyr::mutate(ccdl_filter = ifelse(rownames(filtered_coldata_df) %in%  colnames(processed_sce), 
+                                       "Keep", 
+                                       "Remove")) 
   
   ggplot(filtered_coldata_df, aes(x = detected, y = subsets_mito_percent, color = ccdl_filter)) + 
       geom_point(alpha = 0.5, size = 1) +
       geom_vline(xintercept = min_gene_cutoff, linetype = "dashed") +
       labs(x = "Number of genes detected",
            y = "Mitochondrial percentage",
-           color = "Filter") +
-    ggtitle(stringr::str_replace(filter_method, "_", " ")) +
+           color = "Filter"
+           title = stringr::str_replace(filter_method, "_", " ")) +
     theme(plot.title = element_text(hjust = 0.5),
           legend.position = c(1, 1),
           legend.justification = c(1,1),

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -422,7 +422,7 @@ if(has_filtered & has_processed){
   glue::glue("
     <div class=\"alert alert-warning\">
     
-    No filtering was performed on this library.
+    No filtering of low quality cells was performed on this library.
     
     </div>
   ")

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -407,12 +407,12 @@ if(has_filtered & has_processed){
                                        "Remove")) 
   
   ggplot(filtered_coldata_df, aes(x = detected, y = subsets_mito_percent, color = ccdl_filter)) + 
-      geom_point(alpha = 0.5, size = 1) +
-      geom_vline(xintercept = min_gene_cutoff, linetype = "dashed") +
-      labs(x = "Number of genes detected",
-           y = "Mitochondrial percentage",
-           color = "Filter"
-           title = stringr::str_replace(filter_method, "_", " ")) +
+    geom_point(alpha = 0.5, size = 1) +
+    geom_vline(xintercept = dmin_gene_cutoff, linetype = "dashed") +
+    labs(x = "Number of genes detected",
+         y = "Mitochondrial percentage",
+         color = "Filter",
+         title = stringr::str_replace(filter_method, "_", " ")) +
     theme(plot.title = element_text(hjust = 0.5),
           legend.position = c(1, 1),
           legend.justification = c(1,1),

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -348,6 +348,10 @@ Cells with low UMI counts and high mitochondrial percentages may require further
 if(skip_miQC){
   cat("miQC model not created, skipping miQC plot. Usually this is because mitochondrial gene data was not available.")
 }else{
+  # grab coldata as dataframe for plotting later otherwise we lose the prob compromised values we need to plot filtering 
+  filtered_coldata_df <- colData(filtered_sce) %>%
+    as.data.frame()
+  
   # remove prob_compromised if it exists, as this will cause errors with plotModel
   filtered_sce$prob_compromised <- NULL
   miQC_model <- metadata(filtered_sce)$miQC_model
@@ -380,6 +384,63 @@ Compromised cells are likely to have a fewer genes detected and higher percentag
 If the model has failed to fit properly, the pattern of cells may differ, and there may not be model fit lines.
 This can be the result of a low-quality library or may occur if there is no mitochondrial content, as in the case of a high-quality single-nucleus sample.
 In such situations, the calculated probability of compromise may not be valid (see [miQC vignette](https://bioconductor.org/packages/3.13/bioc/vignettes/miQC/inst/doc/miQC.html#when-not-to-use-miqc) for more details).
+
+## Removing low quality cells
+
+The below plot highlights cells that were removed prior to normalization and dimensionality reduction.
+Cells that should be removed are those that are identified to be low quality cells, such as cells with high probability of being compromised, calculated by `miQC`.
+The method of filtering is indicated above the plot as either `miQC` or `Minimum gene cutoff`. 
+If `miQC`, cells below the specified probability compromised cutoff and above the minimum number of unique genes identified are kept for downstream analyses. 
+If only a `Minimum gene cutoff` is used, then `miQC` is not used and only those cells that pass the minimum number of unique genes identified threshold are retained. 
+The dotted vertical line indicates the minimum gene cutoff used for filtering. 
+
+```{r}
+if(has_filtered & has_processed){
+  
+  min_gene_cutoff <- processed_meta$min_gene_cutoff
+  prob_compromised_cutoff <- processed_meta$prob_compromised_cutoff
+  filter_method <- processed_meta$ccdl_filter_method
+  
+  if(filter_method == "miQC"){
+    
+    filtered_coldata_df <- filtered_coldata_df %>%
+      dplyr::mutate(ccdl_filter = ifelse(prob_compromised <= prob_compromised_cutoff & 
+                                           detected >= min_gene_cutoff, 
+                                         "Keep", 
+                                         "Remove"))
+    
+  } else if(filter_method == "Minimum_gene_cutoff") {
+    
+    filtered_coldata_df <- filtered_coldata_df %>%
+      dplyr::mutate(ccdl_filter = ifelse(detected >= min_gene_cutoff, 
+                                         "Keep", 
+                                         "Remove"))
+    
+  }
+  
+  ggplot(filtered_coldata_df, aes(x = detected, y = subsets_mito_percent, color = ccdl_filter)) + 
+      geom_point(alpha = 0.5, size = 1) +
+      geom_vline(xintercept = min_gene_cutoff, linetype = "dashed") +
+      labs(x = "Number of genes detected",
+           y = "Mitochondrial percentage",
+           color = "Filter") +
+    ggtitle(stringr::str_replace(filter_method, "_", " ")) +
+    theme(plot.title = element_text(hjust = 0.5),
+          legend.position = c(1, 1),
+          legend.justification = c(1,1),
+          legend.background = element_rect(color = "grey20", size= 0.25),
+          legend.title = element_text(hjust = 0.5))
+} else {
+  glue::glue("
+    <div class=\"alert alert-warning\">
+    
+    No filtering was performed on this library.
+    
+    </div>
+  ")
+}
+```
+
 
 
 ## Dimensionality Reduction 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -399,16 +399,15 @@ if(has_filtered & has_processed){
   
   # add column to coldata labeling cells to keep/remove based on filtering method
   filtered_coldata_df <- colData(filtered_sce) |>
-    as.data.frame()
-    
-  filtered_coldata_df <- filtered_coldata_df |>
-    dplyr::mutate(ccdl_filter = ifelse(rownames(filtered_coldata_df) %in%  colnames(processed_sce), 
+    as.data.frame() |>
+    tibble::rownames_to_column("barcode") |>
+    dplyr::mutate(ccdl_filter = ifelse(barcode %in%  colnames(processed_sce), 
                                        "Keep", 
                                        "Remove")) 
   
   ggplot(filtered_coldata_df, aes(x = detected, y = subsets_mito_percent, color = ccdl_filter)) + 
     geom_point(alpha = 0.5, size = 1) +
-    geom_vline(xintercept = dmin_gene_cutoff, linetype = "dashed") +
+    geom_vline(xintercept = min_gene_cutoff, linetype = "dashed") +
     labs(x = "Number of genes detected",
          y = "Mitochondrial percentage",
          color = "Filter",

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -348,10 +348,6 @@ Cells with low UMI counts and high mitochondrial percentages may require further
 if(skip_miQC){
   cat("miQC model not created, skipping miQC plot. Usually this is because mitochondrial gene data was not available.")
 }else{
-  # grab coldata as dataframe for plotting later otherwise we lose the prob compromised values we need to plot filtering 
-  filtered_coldata_df <- colData(filtered_sce) %>%
-    as.data.frame()
-  
   # remove prob_compromised if it exists, as this will cause errors with plotModel
   filtered_sce$prob_compromised <- NULL
   miQC_model <- metadata(filtered_sce)$miQC_model
@@ -399,7 +395,6 @@ if(has_filtered & has_processed){
   
   # grab cutoffs and filtering method from processed sce
   min_gene_cutoff <- processed_meta$min_gene_cutoff
-  prob_compromised_cutoff <- processed_meta$prob_compromised_cutoff
   filter_method <- processed_meta$ccdl_filter_method
   
   # add column to coldata labeling cells to keep/remove based on filtering method


### PR DESCRIPTION
Closes #133 

Here I added a plot below the miQC diagnostics plot highlighting which cells were removed and which cells were kept for further downstream analyses. For this plot I have a check that the library has both the `filtered_sce` and `processed_sce` and if that is the case, I pull the cutoffs and filtering method used from the `processed_sce`. I then used the `colData` from the filtered SCE object since that contains all the cells as well as the individual prob compromised values for each cell prior to removing cells in the processed SCE object. Depending on the filter method I labeled the cells as either keep or remove and then plotted them in a scatter plot, indicating the minimum gene cutoff as a vertical line. 

The only other change I had to make outside of the chunk that makes this plot is actually grabbing the `colData` prior to creating the miQC model plot, otherwise we lose the `prob_compromised` column and can't use that for labeling cells. 

I've attached a copy of the current plot after rendering in the report, but definitely open to suggestions on how to improve the aesthetics or if there's something we can change to make things more informative. 

![image](https://user-images.githubusercontent.com/54039191/199291470-f4934ae6-3cc9-465c-ba1d-847f3bd95329.png)