### PR TITLE
Use matrix math to do collapse introns

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,6 @@ Depends:
 Imports: 
     BiocGenerics,
     dplyr,
-    DelayedArray,
     DropletUtils,
     glue,
     jsonlite,


### PR DESCRIPTION
Closes #139

While doing #136 is probablye *still* the right way to do this, I decided to get back to basics and use matrix multiplication to do the collapsing of intron counts.

So here I am taking the vector of genes that we were using as a grouping variable, finding the unique gene names, and then making a sparse matrix with the original count rows as columns and output genes as rows with 1s to indicate the columns that should be added for each row. Then we do a simple matrix multiplication (taking advantage of whatever sparse matrix optimizations are already present) to get the new matrix of collapsed/aggregated/summed counts.

In testing this, I am a bit confused why the original failed in the case I ran into; I would have expected the tests we already had to catch it, as they do load a real alevin-fry dataset. But here we are.
