### PR TITLE
Tiny doc fixes

### DIFF
--- a/R/sce_to_seurat.R
+++ b/R/sce_to_seurat.R
@@ -4,8 +4,8 @@
 #' @param sce SingleCellExperiment object
 #' @param assay_name The assay name (default "counts") to include in
 #'   the Seurat object. This name will be applied as the assay name in
-#'   the Seurat object. If the default "count" assay is used, then the
-#'   assay name will instead be "RNA".
+#'   the Seurat object. If the default "counts" assay is used, then the
+#'   assay name will instead be "RNA," consistent with Seurat defaults.
 #'
 #' @return Seurat object
 #'


### PR DESCRIPTION
Came across this while preparing for a consult. There's a very small typo fix "count" --> "counts" and I popped in another bit of doc for good measure while I was there!