### PR TITLE
Account for feature data in `read_alevin`

### DIFF
--- a/R/read_alevin.R
+++ b/R/read_alevin.R
@@ -1,7 +1,7 @@
 #' Read in counts data processed with Alevin or Alevin-fry
 #'
 #' @param quant_dir Path to directory where output files are located.
-#' @param fry_mode Logical indicating if Alevin-fry was used, if USA mode was invoked.
+#' @param fry_mode Logical indicating if Alevin-fry was used for quantification.
 #'   Implies the input data is in matrix market format.
 #'   Default is FALSE.
 #' @param include_unspliced Whether or not to include the unspliced reads in the counts matrix.
@@ -96,7 +96,7 @@ read_alevin <- function(quant_dir,
     if(include_unspliced){
       assay_formats <- list("counts" = c("S", "A", "U"), "spliced" = c("S", "A"))
       meta$transcript_type <- c("total", "spliced")
-    } else if(!include_unspliced & !feature_data) {
+    } else if(!feature_data) {
       assay_formats <- list("counts" = c("S", "A"))
       meta$transcript_type <- "spliced"
     } else {
@@ -119,7 +119,7 @@ read_alevin <- function(quant_dir,
     if(include_unspliced){
       meta$transcript_type <- c("total", "spliced")
 
-    } else if(!include_unspliced & !feature_data) {
+    } else if(!feature_data) {
       meta$transcript_type <- "spliced"
     } else {
       meta$transcript_type <- "feature_counts"

--- a/R/read_alevin.R
+++ b/R/read_alevin.R
@@ -1,7 +1,7 @@
 #' Read in counts data processed with Alevin or Alevin-fry
 #'
 #' @param quant_dir Path to directory where output files are located.
-#' @param usa_mode Logical indicating if Alevin-fry was used, if USA mode was invoked.
+#' @param fry_mode Logical indicating if Alevin-fry was used, if USA mode was invoked.
 #'   Implies the input data is in matrix market format.
 #'   Default is FALSE.
 #' @param include_unspliced Whether or not to include the unspliced reads in the counts matrix.
@@ -9,8 +9,11 @@
 #'   assay will contain spliced reads only. If TRUE, requires that data has been aligned to a reference contianing
 #'   spliced and unspliced reads.
 #'   Default is TRUE.
+#' @param feature_data Logical indicating if the data being read in contains feature data.
+#'   Default is FALSE. If feature data is being read in there are no spliced or unspliced reads.
+#'   All reads will be counted and stored in the `counts` assay.
 #' @param round_counts Logical indicating in the count matrix should be rounded to integers on import.
-#'   Only used if `usa_mode` is FALSE. Default is TRUE.
+#'   Only used if `fry_mode` is FALSE. Default is TRUE.
 #' @param library_id Optional library identifier
 #' @param sample_id Optional sample identifier.
 #'   If multiplexed samples are included in a library, this may be a vector.
@@ -37,27 +40,33 @@
 #' # Import output files processed with alevin-fry USA mode
 #' # including all unspliced cDNA in final counts matrix
 #' read_alevin(quant_dir,
-#'             usa_mode = TRUE,
+#'             fry_mode = TRUE,
 #'             include_unspliced = TRUE)
 #'
 #'}
 read_alevin <- function(quant_dir,
-                        usa_mode = FALSE,
+                        fry_mode = FALSE,
                         include_unspliced = TRUE,
+                        feature_data = FALSE,
                         round_counts = TRUE,
                         library_id = NULL,
                         sample_id = NULL,
                         tech_version = NULL){
 
   # checks for *_mode
-  if(!is.logical(usa_mode)){
-    stop("usa_mode must be set as TRUE or FALSE")
+  if(!is.logical(fry_mode)){
+    stop("fry_mode must be set as TRUE or FALSE")
   }
   if(!is.logical(include_unspliced)){
     stop("include_unspliced must be set as TRUE or FALSE")
   }
   if(!is.logical(round_counts)){
     stop("round_counts must be set as TRUE or FALSE")
+  }
+
+  # make sure that include unspliced and feature data are not both set as TRUE
+  if(include_unspliced & feature_data){
+    stop("Feature data does not have unspliced reads, cannot use `include_unspliced=TRUE`")
   }
 
   # check that the expected quant directory exists
@@ -73,7 +82,7 @@ read_alevin <- function(quant_dir,
     sample_id = sample_id)
 
   # if alevin-fry USA and MTX format directly create SCE object with fishpond
-  if(usa_mode) {
+  if(fry_mode) {
 
     # actually check that files are in usa mode
     if(meta$usa_mode != TRUE){
@@ -84,9 +93,13 @@ read_alevin <- function(quant_dir,
     if(include_unspliced){
       assay_formats <- list("counts" = c("S", "A", "U"), "spliced" = c("S", "A"))
       meta$transcript_type <- c("total", "spliced")
-    } else {
+    } else if(!include_unspliced & !feature_data) {
       assay_formats <- list("counts" = c("S", "A"))
       meta$transcript_type <- "spliced"
+    } else {
+      # if using feature data, use default output format for loadFry of scRNA
+      assay_formats <- "scrna"
+      meta$transcript_type <- "feature_counts"
     }
 
     # must be both alevin-fry and usa mode to use fishpond
@@ -94,7 +107,7 @@ read_alevin <- function(quant_dir,
                              outputFormat = assay_formats)
   }
 
-  if(!usa_mode) {
+  if(!fry_mode) {
 
     # read in any non-USA formatted alevin-fry data or Alevin data
     counts <- read_tximport(quant_dir)
@@ -103,8 +116,10 @@ read_alevin <- function(quant_dir,
     if(include_unspliced){
       meta$transcript_type <- c("total", "spliced")
 
-    } else {
+    } else if(!include_unspliced & !feature_data) {
       meta$transcript_type <- "spliced"
+    } else {
+      meta$transcript_type <- "feature_counts"
     }
 
     # generate the SCE object containing either counts and spliced assays or just counts assay

--- a/R/read_alevin.R
+++ b/R/read_alevin.R
@@ -84,9 +84,12 @@ read_alevin <- function(quant_dir,
   # if alevin-fry USA and MTX format directly create SCE object with fishpond
   if(fry_mode) {
 
-    # actually check that files are in usa mode
-    if(meta$usa_mode != TRUE){
-      stop("Output files not in USA mode")
+    # only check for usa mode for non-feature data
+    if(!feature_data){
+      # actually check that files are in usa mode
+      if(meta$usa_mode != TRUE){
+        stop("Output files not in USA mode")
+      }
     }
 
     # define assays to include in SCE object based on include_unspliced

--- a/man/read_alevin.Rd
+++ b/man/read_alevin.Rd
@@ -6,8 +6,9 @@
 \usage{
 read_alevin(
   quant_dir,
-  usa_mode = FALSE,
+  fry_mode = FALSE,
   include_unspliced = TRUE,
+  feature_data = FALSE,
   round_counts = TRUE,
   library_id = NULL,
   sample_id = NULL,
@@ -17,7 +18,7 @@ read_alevin(
 \arguments{
 \item{quant_dir}{Path to directory where output files are located.}
 
-\item{usa_mode}{Logical indicating if Alevin-fry was used, if USA mode was invoked.
+\item{fry_mode}{Logical indicating if Alevin-fry was used, if USA mode was invoked.
 Implies the input data is in matrix market format.
 Default is FALSE.}
 
@@ -27,8 +28,12 @@ assay will contain spliced reads only. If TRUE, requires that data has been alig
 spliced and unspliced reads.
 Default is TRUE.}
 
+\item{feature_data}{Logical indicating if the data being read in contains feature data.
+Default is FALSE. If feature data is being read in there are no spliced or unspliced reads.
+All reads will be counted and stored in the `counts` assay.}
+
 \item{round_counts}{Logical indicating in the count matrix should be rounded to integers on import.
-Only used if `usa_mode` is FALSE. Default is TRUE.}
+Only used if `fry_mode` is FALSE. Default is TRUE.}
 
 \item{library_id}{Optional library identifier}
 
@@ -58,7 +63,7 @@ read_alevin(quant_dir,
 # Import output files processed with alevin-fry USA mode
 # including all unspliced cDNA in final counts matrix
 read_alevin(quant_dir,
-            usa_mode = TRUE,
+            fry_mode = TRUE,
             include_unspliced = TRUE)
 
 }

--- a/tests/testthat/test-read_alevin.R
+++ b/tests/testthat/test-read_alevin.R
@@ -29,7 +29,7 @@ test_that("reading salmon alevin data works", {
 
 test_that("reading alevin-fry USA mode works", {
   sce <- read_alevin(usa_dir,
-                     usa_mode = TRUE,
+                     fry_mode = TRUE,
                      include_unspliced = TRUE,
                      sample_id = sample_ids)
   expect_s4_class(sce, "SingleCellExperiment")
@@ -55,7 +55,7 @@ test_that("reading alevin-fry USA mode works", {
 test_that("reading alevin-fry intron mode works", {
   sce <- read_alevin(intron_dir,
                      include_unspliced = TRUE,
-                     usa_mode = FALSE)
+                     fry_mode = FALSE)
   expect_s4_class(sce, "SingleCellExperiment")
   expect_equal(dim(sce), sce_af_size)
   # check that column names are barcodes


### PR DESCRIPTION
This PR makes some slight changes to `read_alevin` to account for being able to read in both feature data and RNA data. We were previously using an option for `usa_mode` and if it was true, `fishpond::loadFry` was used to load in alevin-fry data, accounting for spliced and unspliced reads. Part of this relied on the data being in USA mode, which is not the case for feature data.

I double checked that this function does work with both USA and non-USA data as there is a check at the beginning of the function that grabs the mode from the json files. However, we were explicitly telling `loadFry` to store either spliced reads only or unspliced and spliced reads in the counts matrix which doesn't really apply to feature data and isn't really what we want. We would instead just want all of the reads to be totaled and stored in `counts` without any additional `spliced` assay.

To account for this, I made a few updates: 

- Changed the option from `usa_mode` to `fry_mode`, which now serves just as a way to say that this data was quantified using alevin-fry and therefore can be read in using `loadFry` rather than specifically referring to USA mode. 
- Added a `feature_data` option which is by default set to `FALSE`. This signifies if the data is feature data or not and if that's the case, the `transcript_type` is set to `feature_counts` and there is only one assay returned, `counts`. This is the case for both alevin and alevin-fry quantified data. 
- I also added a check that both `include_unspliced` and `feature_data` cannot be true at the same time. 

I tested this with some feature data and it should work as expected, so I think this should handle the concerns mentioned in https://github.com/AlexsLemonade/scpca-nf/pull/242#pullrequestreview-1190089579. 