### PR TITLE
Minor QC report fixes

### DIFF
--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -178,6 +178,9 @@ knitr::kable(sample_information, align = 'r') |>
 ## Pre-Processing Information
 
 ```{r }
+# define transcript type
+transcript_type <- paste(unfiltered_meta$transcript_type, collapse = " ")
+
 processing_info <- tibble::tibble(
   "Salmon version"       = format(unfiltered_meta$salmon_version),
   "Alevin-fry version"   = format(unfiltered_meta$alevinfry_version),
@@ -185,9 +188,9 @@ processing_info <- tibble::tibble(
   "Alevin-fry droplet detection"  = format(unfiltered_meta$af_permit_type),
   "Resolution"           = format(unfiltered_meta$af_resolution), 
   "Transcripts included" = dplyr::case_when(
-      format(unfiltered_meta$transcript_type) == c("total", "spliced") ~ "Total and spliced only",
-      format(unfiltered_meta$transcript_type) == "spliced" ~ "Spliced only",
-      TRUE ~ paste(unfiltered_meta$transcript_type, collapse = " "))
+      transcript_type == "spliced" ~ "Spliced only",
+      transcript_type == "total spliced" ~ "Total and spliced only",
+      TRUE ~ transcript_type)
   ) |>
   mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) |>
   t()

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -185,9 +185,9 @@ processing_info <- tibble::tibble(
   "Alevin-fry droplet detection"  = format(unfiltered_meta$af_permit_type),
   "Resolution"           = format(unfiltered_meta$af_resolution), 
   "Transcripts included" = dplyr::case_when(
+      format(unfiltered_meta$transcript_type) == c("total", "spliced") ~ "Total, spliced only",
       format(unfiltered_meta$transcript_type) == "spliced" ~ "Spliced only",
-      format(unfiltered_meta$transcript_type) == "unspliced" ~ "Spliced and unspliced",
-      TRUE ~ format(unfiltered_meta$transcript_type))
+      TRUE ~ paste(unfiltered_meta$transcript_type, collapse = " "))
   ) |>
   mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) |>
   t()

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -188,8 +188,8 @@ processing_info <- tibble::tibble(
   "Alevin-fry droplet detection"  = format(unfiltered_meta$af_permit_type),
   "Resolution"           = format(unfiltered_meta$af_resolution), 
   "Transcripts included" = dplyr::case_when(
-      transcript_type == "spliced" ~ "Spliced only",
       transcript_type == "total spliced" ~ "Total and spliced only",
+      transcript_type == "spliced" ~ "Spliced only",
       TRUE ~ transcript_type)
   ) |>
   mutate(across(.fns = ~ifelse(.x == "NULL", "N/A", .x))) |>

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -390,7 +390,7 @@ If `miQC`, cells below the specified probability compromised cutoff and above th
 If only a `Minimum gene cutoff` is used, then `miQC` is not used and only those cells that pass the minimum number of unique genes identified threshold are retained. 
 The dotted vertical line indicates the minimum gene cutoff used for filtering. 
 
-```{r}
+```{r results='asis'}
 if(has_filtered & has_processed){
   
   # grab cutoffs and filtering method from processed sce
@@ -479,7 +479,7 @@ The above plot shows the UMAP (Uniform Manifold Approximation and Projection) em
 The plots below show the same UMAP embeddings, coloring each cell by the expression level of the labeled gene.
 The genes chosen for plotting are the 12 most variable genes identified in the library.
 
-```{r message=FALSE}
+```{r message=FALSE, results='asis'}
 if(has_processed & has_var_genes){
   
   # select top genes to plot 

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -185,7 +185,7 @@ processing_info <- tibble::tibble(
   "Alevin-fry droplet detection"  = format(unfiltered_meta$af_permit_type),
   "Resolution"           = format(unfiltered_meta$af_resolution), 
   "Transcripts included" = dplyr::case_when(
-      format(unfiltered_meta$transcript_type) == c("total", "spliced") ~ "Total, spliced only",
+      format(unfiltered_meta$transcript_type) == c("total", "spliced") ~ "Total and spliced only",
       format(unfiltered_meta$transcript_type) == "spliced" ~ "Spliced only",
       TRUE ~ paste(unfiltered_meta$transcript_type, collapse = " "))
   ) |>


### PR DESCRIPTION
We were seeing some issues with the QC report, specifically the warnings for the newly added plots were not printing correctly and the table that included the transcript type was double printing. This PR should address those issues. I generated a report without a processed SCE object to make sure the warnings were printing correctly and the table looked okay and attached it here. 
[SCPCL000050_qc_report.html.zip](https://github.com/AlexsLemonade/scpcaTools/files/10077877/SCPCL000050_qc_report.html.zip)
