### PR TITLE
Quiet build check warnings

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,7 +18,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: r-lib/actions/setup-r@v2
       - name: Remove renv
         run: rm -f renv.lock .Rprofile


### PR DESCRIPTION
This is a tiny fix to update the checkout action version so github stops complaining