### PR TITLE
Account for potential NA in gene symbols for UMAPs of HVGs in QC report

### DIFF
--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -503,7 +503,8 @@ if(has_processed & has_var_genes){
     tibble::rownames_to_column("ensembl_id") |>
     select(ensembl_id, gene_symbol) |>
     filter(ensembl_id %in% top_genes) |>
-    mutate(ensembl_id = factor(ensembl_id, levels = top_genes)) |>
+    mutate(gene_symbol = ifelse(!is.na(gene_symbol), gene_symbol, ensembl_id),
+         ensembl_id = factor(ensembl_id, levels = top_genes)) |>
     arrange(ensembl_id) |>
     mutate(gene_symbol = factor(gene_symbol, levels = gene_symbol))
   

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -481,6 +481,8 @@ The raw counts from all remaining cells are then normalized prior to selection o
 The above plot shows the UMAP (Uniform Manifold Approximation and Projection) embeddings for each cell, coloring each cell by the total number of genes detected per cell.
 The plots below show the same UMAP embeddings, coloring each cell by the expression level of the labeled gene.
 The genes chosen for plotting are the 12 most variable genes identified in the library.
+Gene symbols are used when available to label the UMAP plots.
+If gene symbols are not available, the Ensembl ID will be shown.
 
 ```{r message=FALSE, results='asis'}
 if(has_processed & has_var_genes){


### PR DESCRIPTION
In testing AlexsLemonade/scpca-nf#245 with the new release of `scpcaTools`, I noticed that for one of the libraries I was testing the UMAPs of the HVGs was showing one plot labeled with `NA` rather than a gene symbol. In going back to figure out why that was the case, it was because the ensembl ID for that particular HVG did not map to a gene symbol and we are using gene symbols to label the plots. I adjusted for this by using the ensembl ID for the label if a gene symbol isn't available. I updated the code and also added a note in the report about the labels. 