### PR TITLE
add miQC options to add_miQC

### DIFF
--- a/R/add_miQC.R
+++ b/R/add_miQC.R
@@ -3,6 +3,8 @@
 #'
 #' @param sce SingleCellExperiment object.
 #' @param posterior_cutoff Optional posterior cutoff used for the miQC filtering calculation (default 0.75)
+#' @param keep_all_below_boundary Option to be passed to miQC::filterCells() (default TRUE)
+#' @param enforce_left_cutoff Option to be passed to miQC::filterCells() (default TRUE)
 #' @param seed An optional random seed for reproducibility.
 #'
 #' @return SingleCellExperiment with prob_compromised column added to colData
@@ -12,7 +14,11 @@
 #'
 #' @export
 #'
-add_miQC <- function(sce, posterior_cutoff = 0.75, seed = NULL){
+add_miQC <- function(sce,
+                     posterior_cutoff = 0.75,
+                     keep_all_below_boundary = TRUE,
+                     enforce_left_cutoff = TRUE,
+                     seed = NULL){
   # check that input is a SingleCellExperiment
   if(!is(sce, "SingleCellExperiment")){
     stop("sce must be a SingleCellExperiment object")
@@ -50,6 +56,8 @@ add_miQC <- function(sce, posterior_cutoff = 0.75, seed = NULL){
         miQC::filterCells(sce,
                           model = model,
                           posterior_cutoff = posterior_cutoff,
+                          keep_all_below_boundary = keep_all_below_boundary,
+                          enforce_left_cutoff = enforce_left_cutoff,
                           verbose = FALSE)
       )
     }, silent = TRUE)

--- a/man/add_miQC.Rd
+++ b/man/add_miQC.Rd
@@ -4,12 +4,22 @@
 \alias{add_miQC}
 \title{Add miQC model and probability compromised to a SingleCellExperiment object}
 \usage{
-add_miQC(sce, posterior_cutoff = 0.75, seed = NULL)
+add_miQC(
+  sce,
+  posterior_cutoff = 0.75,
+  keep_all_below_boundary = TRUE,
+  enforce_left_cutoff = TRUE,
+  seed = NULL
+)
 }
 \arguments{
 \item{sce}{SingleCellExperiment object.}
 
 \item{posterior_cutoff}{Optional posterior cutoff used for the miQC filtering calculation (default 0.75)}
+
+\item{keep_all_below_boundary}{Option to be passed to miQC::filterCells() (default TRUE)}
+
+\item{enforce_left_cutoff}{Option to be passed to miQC::filterCells() (default TRUE)}
 
 \item{seed}{An optional random seed for reproducibility.}
 }


### PR DESCRIPTION
Does what it says on the tin... A small change to our `add_miQC()` function to add in some options that we can pass to miQC filtering, with the same defaults as the current version of miQC. I considered passing them with `...` but that woudl have required a few more checks to be sure there were not duplicated options, so I went with this slightly more verbose but explicit version.