### PR TITLE
Make UMAP plotting optional

### DIFF
--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -88,7 +88,46 @@ has_cellhash <- "cellhash" %in% altExpNames(filtered_sce)
 if(has_cellhash){
   modalities <- c(modalities, "Multiplex")
 }
+
+# check for umap, need to be sure that processed_sce exists first
+if(has_processed){
+  has_umap <- "UMAP" %in% reducedDimNames(processed_sce)
+} else {
+  has_umap <- FALSE
+}
 ```
+
+```{r, results='asis'}
+# check for number of filtered cells
+if(has_filtered){
+  if(ncol(filtered_sce) > 100){
+    glue::glue("
+      <div class=\"alert alert-warning\">
+      
+      This library contains fewer than 100 cells post removal of empty droplets.
+      This may affect the interpretation of results.
+      
+      </div>
+    ")
+  } 
+}
+
+# check for number of cells post processing
+if(has_processed){
+  if(ncol(processed_sce) > 50){
+    glue::glue("
+      <div class=\"alert alert-warning\">
+      
+      This library contains fewer than 50 cells post removal of low quality cells.
+      UMAP is unable to be calculated and plots will not be shown.
+      
+      
+      </div>
+    ")
+  }  
+}
+```
+
 
 # Processing Information for `r library_id`
 
@@ -431,136 +470,10 @@ if(has_filtered & has_processed){
 }
 ```
 
+<!-- Next section include only if UMAP is present -->
+```{r, child='umap_qc.rmd', eval = has_umap}
 
-
-## Dimensionality Reduction 
-
-```{r message=FALSE}
-if(has_processed){
-  
-  # use to check if variable genes are present, need for both UMAPs
-  has_var_genes <- !is.null(processed_meta$highly_variable_genes)
-
-  # check that processed SCE contains UMAP and PCA
-  if(!"UMAP" %in% reducedDimNames(processed_sce)){
-    if(!"PCA" %in% reducedDimNames(processed_sce)){
-      
-      # if PCA is missing, check for HVG, if no HVG use all genes 
-      if(has_var_genes){
-        subset_genes <- processed_meta$highly_variable_genes
-      }else{
-        subset_genes <- rownames(processed_sce)
-      }
-      processed_sce <- scater::runPCA(processed_sce,
-                                      subset_row = subset_genes)
-    }
-    
-    processed_sce <- scater::runUMAP(processed_sce, 
-                                     dimred = "PCA")
-  }
-  
-  # create UMAP colored by number of genes detected 
-  scater::plotUMAP(processed_sce,
-                   point_size = 0.3,
-                   point_alpha = 0.5,
-                   colour_by = "detected") +
-    scale_color_viridis_c()+
-    theme_bw() + 
-    guides(
-      color = guide_colorbar(title = "Number of \ngenes detected")
-    )
-  
-} else {
-  # if processed is missing, set to null to skip next UMAPs
-  has_var_genes <- FALSE
-}
 ```
-
-Compromised cells, calculated using `miQC` described above, are filtered and removed from the library prior to downstream analyses. 
-The raw counts from all remaining cells are then normalized prior to selection of highly variable genes and dimensionality reduction. 
-The above plot shows the UMAP (Uniform Manifold Approximation and Projection) embeddings for each cell, coloring each cell by the total number of genes detected per cell.
-The plots below show the same UMAP embeddings, coloring each cell by the expression level of the labeled gene.
-The genes chosen for plotting are the 12 most variable genes identified in the library.
-Gene symbols are used when available to label the UMAP plots.
-If gene symbols are not available, the Ensembl ID will be shown.
-
-```{r message=FALSE, results='asis'}
-if(has_processed & has_var_genes){
-  
-  # select top genes to plot 
-  top_genes <- processed_meta$highly_variable_genes |>
-    head(n=12)
-  
-  # grab expression for top genes from counts
-  var_gene_exp <- logcounts(processed_sce[top_genes,]) |>
-    as.matrix() |>
-    t() |>
-    as.data.frame() |>
-    tibble::rownames_to_column("barcode")
-  
-  # grab rowdata as data frame to later combine with gene expression data
-  # rowdata contains the mapped gene symbol so can use that to label plots instead of ensembl gene id from rownames 
-  rowdata_df <- rowData(processed_sce) |>
-    as.data.frame() |>
-    tibble::rownames_to_column("ensembl_id") |>
-    select(ensembl_id, gene_symbol) |>
-    filter(ensembl_id %in% top_genes) |>
-    mutate(gene_symbol = ifelse(!is.na(gene_symbol), gene_symbol, ensembl_id),
-         ensembl_id = factor(ensembl_id, levels = top_genes)) |>
-    arrange(ensembl_id) |>
-    mutate(gene_symbol = factor(gene_symbol, levels = gene_symbol))
-  
-  
-  # extract umap embeddings as a dataframe to join with gene expression and coldata for plotting
-  umap_df <- reducedDim(processed_sce, "UMAP") |>
-    as.data.frame() |>
-    tibble::rownames_to_column("barcode") |>
-    rename("UMAP1" = "V1",
-           "UMAP2" = "V2")
-  
-  # combine gene expression with coldata, umap embeddings, and rowdata and create data frame to use for plotting
-  coldata_df <- colData(processed_sce) |>
-    as.data.frame() |>
-    tibble::rownames_to_column("barcode") |>
-    # combine with gene expression
-    left_join(var_gene_exp, by = "barcode") |>
-    # combine with umap embeddings 
-    left_join(umap_df, by = "barcode") |>
-    # combine all genes into a single column for easy faceting 
-    tidyr::pivot_longer(cols = starts_with("ENSG"),
-                        names_to = "ensembl_id",
-                        values_to = "gene_expression") |>
-    # join with row data to add in gene symbols 
-    left_join(rowdata_df)
-  
-  
-  ggplot(coldata_df, aes(x = UMAP1, y = UMAP2, color = gene_expression)) + 
-    geom_point(alpha = 0.1, size = 0.001) + 
-    facet_wrap(~ gene_symbol) +
-    scale_color_viridis_c() +
-    labs(
-      color = "Log-normalized gene expression"
-    ) +
-    theme(legend.position = "bottom", 
-          axis.text = element_text(size = 8, color = "black"),
-          axis.title = element_text(size = 8, color = "black"),
-          strip.text = element_text(size = 8),
-          strip.background = element_rect(fill = 'transparent'),
-          legend.title = element_text(size = 8),
-          legend.text = element_text(size = 8)) + 
-    guides(colour = guide_colorbar(title.position = "bottom", title.hjust = 0.5))
-  
-} else {
-  glue::glue("
-    <div class=\"alert alert-warning\">
-    
-    This library does not contain a set of highly variable genes. 
-    
-    </div>
-  ")
-}
-```
-
 
 <!-- Next section included only if CITE-seq data is present -->
 ```{r, child='cite_qc.rmd', eval = has_cite}

--- a/inst/rmd/qc_report.rmd
+++ b/inst/rmd/qc_report.rmd
@@ -97,37 +97,6 @@ if(has_processed){
 }
 ```
 
-```{r, results='asis'}
-# check for number of filtered cells
-if(has_filtered){
-  if(ncol(filtered_sce) > 100){
-    glue::glue("
-      <div class=\"alert alert-warning\">
-      
-      This library contains fewer than 100 cells post removal of empty droplets.
-      This may affect the interpretation of results.
-      
-      </div>
-    ")
-  } 
-}
-
-# check for number of cells post processing
-if(has_processed){
-  if(ncol(processed_sce) > 50){
-    glue::glue("
-      <div class=\"alert alert-warning\">
-      
-      This library contains fewer than 50 cells post removal of low quality cells.
-      UMAP is unable to be calculated and plots will not be shown.
-      
-      
-      </div>
-    ")
-  }  
-}
-```
-
 
 # Processing Information for `r library_id`
 
@@ -305,6 +274,36 @@ if(has_filtered &&
 }
 ```
 
+```{r, results='asis'}
+# check for number of filtered cells
+if(has_filtered){
+  if(ncol(filtered_sce) < 100){
+    glue::glue("
+      <div class=\"alert alert-warning\">
+      
+      This library contains fewer than 100 cells in the filtered `SingleCellExperiment` object.
+      This may affect the interpretation of results.
+      
+      </div>
+    ")
+  } 
+}
+
+# check for number of cells post processing
+if(has_processed){
+  if(ncol(processed_sce) < 50){
+    glue::glue("
+      <div class=\"alert alert-warning\">
+      
+      This library contains fewer than 50 cells in the processed `SingleCellExperiment` object after removal of low quality cells.
+      UMAP is unable to be calculated and plots will not be shown.
+      
+      
+      </div>
+    ")
+  }  
+}
+```
 
 ## Knee Plot
 

--- a/inst/rmd/umap_qc.rmd
+++ b/inst/rmd/umap_qc.rmd
@@ -1,0 +1,100 @@
+## Dimensionality Reduction 
+
+```{r message=FALSE}
+# create UMAP colored by number of genes detected 
+scater::plotUMAP(processed_sce,
+                 point_size = 0.3,
+                 point_alpha = 0.5,
+                 colour_by = "detected") +
+  scale_color_viridis_c()+
+  theme_bw() + 
+  guides(
+    color = guide_colorbar(title = "Number of \ngenes detected")
+  )
+```
+
+Compromised cells, calculated using `miQC` described above, are filtered and removed from the library prior to downstream analyses. 
+The raw counts from all remaining cells are then normalized prior to selection of highly variable genes and dimensionality reduction. 
+The above plot shows the UMAP (Uniform Manifold Approximation and Projection) embeddings for each cell, coloring each cell by the total number of genes detected per cell.
+The plots below show the same UMAP embeddings, coloring each cell by the expression level of the labeled gene.
+The genes chosen for plotting are the 12 most variable genes identified in the library.
+Gene symbols are used when available to label the UMAP plots.
+If gene symbols are not available, the Ensembl ID will be shown.
+
+```{r message=FALSE, results='asis'}
+# only create plot if variable genes are present
+if(!is.null(processed_meta$highly_variable_genes)){
+  
+  # select top genes to plot 
+  top_genes <- processed_meta$highly_variable_genes |>
+    head(n=12)
+  
+  # grab expression for top genes from counts
+  var_gene_exp <- logcounts(processed_sce[top_genes,]) |>
+    as.matrix() |>
+    t() |>
+    as.data.frame() |>
+    tibble::rownames_to_column("barcode")
+  
+  # grab rowdata as data frame to later combine with gene expression data
+  # rowdata contains the mapped gene symbol so can use that to label plots instead of ensembl gene id from rownames 
+  rowdata_df <- rowData(processed_sce) |>
+    as.data.frame() |>
+    tibble::rownames_to_column("ensembl_id") |>
+    select(ensembl_id, gene_symbol) |>
+    filter(ensembl_id %in% top_genes) |>
+    mutate(gene_symbol = ifelse(!is.na(gene_symbol), gene_symbol, ensembl_id),
+         ensembl_id = factor(ensembl_id, levels = top_genes)) |>
+    arrange(ensembl_id) |>
+    mutate(gene_symbol = factor(gene_symbol, levels = gene_symbol))
+  
+  
+  # extract umap embeddings as a dataframe to join with gene expression and coldata for plotting
+  umap_df <- reducedDim(processed_sce, "UMAP") |>
+    as.data.frame() |>
+    tibble::rownames_to_column("barcode") |>
+    rename("UMAP1" = "V1",
+           "UMAP2" = "V2")
+  
+  # combine gene expression with coldata, umap embeddings, and rowdata and create data frame to use for plotting
+  coldata_df <- colData(processed_sce) |>
+    as.data.frame() |>
+    tibble::rownames_to_column("barcode") |>
+    # combine with gene expression
+    left_join(var_gene_exp, by = "barcode") |>
+    # combine with umap embeddings 
+    left_join(umap_df, by = "barcode") |>
+    # combine all genes into a single column for easy faceting 
+    tidyr::pivot_longer(cols = starts_with("ENSG"),
+                        names_to = "ensembl_id",
+                        values_to = "gene_expression") |>
+    # join with row data to add in gene symbols 
+    left_join(rowdata_df)
+  
+  
+  ggplot(coldata_df, aes(x = UMAP1, y = UMAP2, color = gene_expression)) + 
+    geom_point(alpha = 0.1, size = 0.001) + 
+    facet_wrap(~ gene_symbol) +
+    scale_color_viridis_c() +
+    labs(
+      color = "Log-normalized gene expression"
+    ) +
+    theme(legend.position = "bottom", 
+          axis.text = element_text(size = 8, color = "black"),
+          axis.title = element_text(size = 8, color = "black"),
+          strip.text = element_text(size = 8),
+          strip.background = element_rect(fill = 'transparent'),
+          legend.title = element_text(size = 8),
+          legend.text = element_text(size = 8)) + 
+    guides(colour = guide_colorbar(title.position = "bottom", title.hjust = 0.5))
+  
+} else {
+  glue::glue("
+    <div class=\"alert alert-warning\">
+    
+    This library does not contain a set of highly variable genes. 
+    
+    </div>
+  ")
+}
+```


### PR DESCRIPTION
Closes #158 

This PR splits out any of the UMAP plots into their own child report that is only included if the `processed_sce` object that is provided includes UMAP results. I took everything from the `Dimensionality reduction` heading and moved into its own notebook that gets loaded in if UMAP results are present. 

Originally we were checking for if the processed SCE object had UMAP results and if they were not present, we were adding them in. Here I changed to just check for the UMAP being present and if it's not no plots are being produced and we aren't attempting to recalculate it. This makes it a little simpler because we also had some checks for PCA and using variable genes as well. I was torn on if this was the right approach, but having a nice warning that no UMAP plots are present rather than attempting to re-calculate and have it fail again seemed to make the most sense to me. 

I also added two warning messages, one for a low number of cells in the filtered SCE object (n < 100) and one for a low number of cells in the processed SCE object (n < 50). I chose the 50 cutoff because that's when the UMAP will fail and the 100 cutoff because that's when we have issues with normalization, but I'm open to changing them or adding other warnings for different cutoffs if we think those are necessary. 

I tested these changes with a library that didn't have any issues: 
[SCPCL000050_qc_report.html.zip](https://github.com/AlexsLemonade/scpcaTools/files/10348015/SCPCL000050_qc_report.html.zip)


And then the one that failed UMAP: 
[SCPCL000784_qc_report.html.zip](https://github.com/AlexsLemonade/scpcaTools/files/10348016/SCPCL000784_qc_report.html.zip)
