### PR TITLE
Add argument for highly variable genes to integration function

### DIFF
--- a/R/integrate_sces.R
+++ b/R/integrate_sces.R
@@ -11,6 +11,9 @@
 #' @param integration_method The integration method to use. One of `fastMNN` or
 #'  `harmony` (case-sensitive)
 #' @param batch_column The column in the merged SCE object indicating batches
+#' @param hv_genes A vector specifying which highly variable features to use for correction.
+#'   This argument will only be used if integrating with `fastMNN` and ignored with `harmony`.
+#'   Default is `NULL`.
 #' @param covariate_cols A vector of additional columns in the merged SCE to
 #'   consider as covariates during integration. Currently, this is used only by
 #'   `harmony`.
@@ -31,6 +34,7 @@
 integrate_sces <- function(merged_sce,
                            integration_method = c("fastMNN", "harmony"),
                            batch_column = "sample",
+                           hv_genes = NULL,
                            covariate_cols = c(),
                            return_corrected_expression = FALSE,
                            seed = NULL,
@@ -72,6 +76,7 @@ integrate_sces <- function(merged_sce,
 
     integrated_sce <- integrate_fastmnn(merged_sce,
                                         batch_column,
+                                        subset.row = hv_genes,
                                         ...)
     # Add corrected expression to merged_sce if specified
     if (return_corrected_expression) {
@@ -85,6 +90,10 @@ integrate_sces <- function(merged_sce,
     # warn that this is not possible
     if (return_corrected_expression) {
       warning("`harmony` does not calculate corrected expression values, so none can be returned.")
+    }
+
+    if(!is.null(hv_genes)){
+      warning("`harmony` does not consider highly variable genes and `hv_genes` will be ignroed.")
     }
 
     # here the result is the PCs:

--- a/R/integrate_sces.R
+++ b/R/integrate_sces.R
@@ -76,7 +76,7 @@ integrate_sces <- function(merged_sce,
 
     integrated_sce <- integrate_fastmnn(merged_sce,
                                         batch_column,
-                                        subset.row = hv_genes,
+                                        hv_genes,
                                         ...)
     # Add corrected expression to merged_sce if specified
     if (return_corrected_expression) {
@@ -118,6 +118,7 @@ integrate_sces <- function(merged_sce,
 #'
 #' @param merged_sce A merged SCE object as prepared by `scpcaTools::merge_sce_list()`.
 #' @param batch_column The variable in `merged_sce` indicating batches.
+#' @param hv_genes A vector specifying which highly variable features to use for correction.
 #' @param ... Additional arguments to pass into `batchelor::fastMNN()`
 #'
 #' @return An integrated SCE object produced by `fastMNN`
@@ -125,6 +126,7 @@ integrate_sces <- function(merged_sce,
 #' @import SingleCellExperiment
 integrate_fastmnn <- function(merged_sce,
                               batch_column,
+                              hv_genes = NULL,
                               ...) {
 
   # Check that batchelor is installed
@@ -140,6 +142,7 @@ integrate_fastmnn <- function(merged_sce,
   # Perform integration
   integrated_sce <- batchelor::fastMNN(merged_sce,
                                        batch = colData(merged_sce)[,batch_column],
+                                       subset.row = hv_genes,
                                        ...)
 
   return(integrated_sce)

--- a/man/integrate_fastmnn.Rd
+++ b/man/integrate_fastmnn.Rd
@@ -6,12 +6,14 @@
 approach from the `batchelor` package.
 Source: http://www.bioconductor.org/packages/release/bioc/html/batchelor.html}
 \usage{
-integrate_fastmnn(merged_sce, batch_column, ...)
+integrate_fastmnn(merged_sce, batch_column, hv_genes, ...)
 }
 \arguments{
 \item{merged_sce}{A merged SCE object as prepared by `scpcaTools::merge_sce_list()`.}
 
 \item{batch_column}{The variable in `merged_sce` indicating batches.}
+
+\item{hv_genes}{A vector specifying which highly variable features to use for correction.}
 
 \item{...}{Additional arguments to pass into `batchelor::fastMNN()`}
 }

--- a/man/integrate_sces.Rd
+++ b/man/integrate_sces.Rd
@@ -12,6 +12,7 @@ integrate_sces(
   merged_sce,
   integration_method = c("fastMNN", "harmony"),
   batch_column = "sample",
+  hv_genes = NULL,
   covariate_cols = c(),
   return_corrected_expression = FALSE,
   seed = NULL,
@@ -25,6 +26,10 @@ integrate_sces(
 `harmony` (case-sensitive)}
 
 \item{batch_column}{The column in the merged SCE object indicating batches}
+
+\item{hv_genes}{A vector specifying which highly variable features to use for correction.
+This argument will only be used if integrating with `fastMNN` and ignored with `harmony`.
+Default is `NULL`.}
 
 \item{covariate_cols}{A vector of additional columns in the merged SCE to
 consider as covariates during integration. Currently, this is used only by


### PR DESCRIPTION
In working on adding the steps for integration to the workflow in `scpca-nf`, I noticed that we don't explicitly have an option to indicate using highly variable genes for integration with `fastMNN`. Considering that we pretty much exclusively are running `fastMNN` with only highly variable genes, I think it makes sense to add that in. We do pass additional arguments through using `...`, but the problem is here we are using one function for integration that will either perform `fastMNN` or `harmony`, so any options that are being passed to the function that are not compatible with one of the methods will cause an error. 

This is mostly problematic when writing the script to perform both types of integration in `scpca-nf`, because we only want to provide the highly variable genes with `fastMNN` and not for `harmony`. One way around this would be to call the function differently depending on the integration method being used as input, but that seemed like overkill for one argument that is different. We also have already accounted for dealing with harmony covariates and ignoring them for `fastMNN`, so I decided to take the same approach with the highly variable genes. I set them to be `NULL` by default, but if they are used they will only be passed through to `fastMNN`, otherwise they are ignored and a warning is printed. 

Another thought I had when working on this was getting rid of the wrapper function entirely... so that all of the things that happen in the wrapper function to distinguish `harmony` vs. `fastMNN` would happen in `scpca-nf` instead, but given we are also planning to use integration in other places (like downstream analyses), I talked myself out of that.