### PR TITLE
specify CRAN repo and fix linux version

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -10,7 +10,7 @@ jobs:
   document:
     if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/document') }}
     name: document
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -48,7 +48,7 @@ jobs:
   style:
     if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/style') }}
     name: style
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -61,7 +61,7 @@ jobs:
       - uses: r-lib/actions/setup-r@v2
 
       - name: Install dependencies
-        run: install.packages(c("styler", "roxygen2"))
+        run: install.packages(c("styler", "roxygen2"), repos = "https://packagemanager.posit.co/cran/__linux__/jammy/latest")
         shell: Rscript --no-init-file {0}
 
       - name: Enable styler cache


### PR DESCRIPTION
This [action failed](https://github.com/AlexsLemonade/scpcaTools/actions/runs/5577935213/jobs/10191413471) because of an unspecified CRAN mirror (which it did not do in testing, curiously enough), so here I am adding the Posit mirror and fixing the ubuntu version to match it.

No major changes...