### PR TITLE
Remove rprofile before setup

### DIFF
--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -3,15 +3,12 @@
 on:
   issue_comment:
     types: [created]
-  push:
-    branches:
-      - jashapiro/fix-documentation-action
 
 name: Commands
 
 jobs:
   document:
-    if: ${{ github.event_name == 'push' || (github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/document')) }}
+    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/document') }}
     name: document
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -3,15 +3,15 @@
 on:
   issue_comment:
     types: [created]
-  pull_request:
+  push:
     branches:
-      - main
+      - jashapiro/fix-documentation-action
 
 name: Commands
 
 jobs:
   document:
-    if: ${{ github.event_name == 'pull_request' || (github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/document')) }}
+    if: ${{ github.event_name == 'push' || (github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/document')) }}
     name: document
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -3,15 +3,15 @@
 on:
   issue_comment:
     types: [created]
-  push:
+  pull_request:
     branches:
-      - jashapiro/fix-documentation-action
+      - main
 
 name: Commands
 
 jobs:
   document:
-    if: ${{ github.event_name == 'push' || (github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/document')) }}
+    if: ${{ github.event_name == 'pull_request' || (github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/document')) }}
     name: document
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -20,6 +20,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: remove Rprofile
+        run: rm -r .Rprofile
+
       - uses: r-lib/actions/setup-r@v2
         with:
           use-public-rspm: true

--- a/.github/workflows/pr-commands.yaml
+++ b/.github/workflows/pr-commands.yaml
@@ -3,12 +3,15 @@
 on:
   issue_comment:
     types: [created]
+  push:
+    branches:
+      - jashapiro/fix-documentation-action
 
 name: Commands
 
 jobs:
   document:
-    if: ${{ github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/document') }}
+    if: ${{ github.event_name == 'push' || (github.event.issue.pull_request && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER') && startsWith(github.event.comment.body, '/document')) }}
     name: document
     runs-on: ubuntu-22.04
     env:

--- a/man/add_cell_mito_qc.Rd
+++ b/man/add_cell_mito_qc.Rd
@@ -26,8 +26,10 @@ Calculate QC metrics for all reads and mitochondrial subset for each cell in a S
 \examples{
 \dontrun{
 # add per cell QC metrics using only genes detected > 5\% of cells
-add_cell_mito_qc(sce = sce,
-                 mito = mito_genes,
-                 threshold = 5)
+add_cell_mito_qc(
+  sce = sce,
+  mito = mito_genes,
+  threshold = 5
+)
 }
 }

--- a/man/add_cellhash_ids.Rd
+++ b/man/add_cellhash_ids.Rd
@@ -31,7 +31,9 @@ Add cellhash sample information to altExperiment rowData
 \examples{
 \dontrun{
 # add sample information for a cellhash table
-add_cellhash_ids(sce = sce,
-                 hashsample_table = barcode_ids)
+add_cellhash_ids(
+  sce = sce,
+  hashsample_table = barcode_ids
+)
 }
 }

--- a/man/add_demux_hashedDrops.Rd
+++ b/man/add_demux_hashedDrops.Rd
@@ -24,7 +24,7 @@ Add cellhash demultiplexing results using DropletUtils::hashedDrops
 }
 \examples{
 \dontrun{
-  # add cell calls from DropletUtils::hashedDrops()
-  add_demux_hashedDrops(sce = sce)
+# add cell calls from DropletUtils::hashedDrops()
+add_demux_hashedDrops(sce = sce)
 }
 }

--- a/man/add_demux_seurat.Rd
+++ b/man/add_demux_seurat.Rd
@@ -24,7 +24,7 @@ Add cellhash demultiplexing results using Seurat::HTODemux()
 }
 \examples{
 \dontrun{
-  # add cell calls from Seurat::HTODemux()
-  add_demux_seurat(sce = sce)
+# add cell calls from Seurat::HTODemux()
+add_demux_seurat(sce = sce)
 }
 }

--- a/man/add_demux_vireo.Rd
+++ b/man/add_demux_vireo.Rd
@@ -23,7 +23,7 @@ Add genetic demultiplexing results to a SCE object from Vireo
 }
 \examples{
 \dontrun{
-  # add cell calls from a vireo data frame
-  add_demux_vireo(sce, vireo_table = vireo_df)
+# add cell calls from a vireo data frame
+add_demux_vireo(sce, vireo_table = vireo_df)
 }
 }

--- a/man/build_sce.Rd
+++ b/man/build_sce.Rd
@@ -37,7 +37,7 @@ build_sce(counts)
 # build a SCE object with unspliced cDNA as the main counts assay and spliced
 # counts as a second assay
 build_sce(counts,
-          include_unspliced = TRUE)
-
+  include_unspliced = TRUE
+)
 }
 }

--- a/man/collapse_intron_counts.Rd
+++ b/man/collapse_intron_counts.Rd
@@ -30,13 +30,13 @@ Merge counts from intron reads with corresponding cDNA reads
 
 # only keep counts from spliced cDNA in final counts matrix
 collapse_intron_counts(counts,
-                       which_counts = "spliced")
+  which_counts = "spliced"
+)
 
 # include unspliced cDNA in final counts matrix
 collapse_intron_counts(counts,
-                       which_counts = "total")
+  which_counts = "total"
+)
 }
-
-
 
 }

--- a/man/import_quant_data.Rd
+++ b/man/import_quant_data.Rd
@@ -49,29 +49,33 @@ Imports the gene x cell matrix output from either Alevin, Alevin-fry, Cellranger
 \dontrun{
 # read in single cell RNA seq data processed using cellranger
 import_quant_data(quant_dir,
-tool = "cellranger")
+  tool = "cellranger"
+)
 
 # read in single-cell RNA seq data processed using alevin-fry in USA mode
 # with alignment to cDNA only and including counts for spliced cDNA only
 import_quant_data(quant_dir,
-                  tool = "alevin-fry",
-                  include_unspliced = FALSE,
-                  usa_mode = TRUE)
+  tool = "alevin-fry",
+  include_unspliced = FALSE,
+  usa_mode = TRUE
+)
 
 # read in single-nuclei RNA-seq data processed using alevin-fry in
 # USA mode with alignment to cDNA + introns and including counts for
 # unspliced cDNA and perform filtering
 import_quant_data(quant_dir,
-                  tool = "alevin-fry",
-                  usa_mode = TRUE,
-                  filter = TRUE)
+  tool = "alevin-fry",
+  usa_mode = TRUE,
+  filter = TRUE
+)
 
 # read in single-nuclei RNA-seq data processed using kallisto with
 # alignment to cDNA + introns and including counts for unspliced cDNA
 # and perform filtering
 import_quant_data(quant_dir,
-                  tool = "kallisto",
-                  filter = TRUE)
+  tool = "kallisto",
+  filter = TRUE
+)
 }
 
 }

--- a/man/read_alevin.Rd
+++ b/man/read_alevin.Rd
@@ -58,13 +58,14 @@ read_alevin(quant_dir)
 # Import output files processed with either Alevin or Alevin-fry with alignment to
 # cDNA + introns and including all unspliced cDNA in final counts matrix
 read_alevin(quant_dir,
-            include_unspliced = TRUE)
+  include_unspliced = TRUE
+)
 
 # Import output files processed with alevin-fry USA mode
 # including all unspliced cDNA in final counts matrix
 read_alevin(quant_dir,
-            fry_mode = TRUE,
-            include_unspliced = TRUE)
-
+  fry_mode = TRUE,
+  include_unspliced = TRUE
+)
 }
 }

--- a/man/read_cellranger.Rd
+++ b/man/read_cellranger.Rd
@@ -20,7 +20,6 @@ Read in counts data processed with Cellranger
 
 # Import data from cellranger output directory quant_dir
 read_cellranger(quant_dir)
-
 }
 
 }

--- a/man/read_kallisto.Rd
+++ b/man/read_kallisto.Rd
@@ -30,7 +30,8 @@ Read in counts data processed with Kallisto
 # import output files processed with kallisto with alignment to cDNA + introns,
 # including all unspliced cDNA counts in final counts matrix
 read_kallisto(quant_dir,
-              include_unspliced = TRUE,
-              which_counts = "unspliced")
+  include_unspliced = TRUE,
+  which_counts = "unspliced"
+)
 }
 }

--- a/man/sce_to_anndata.Rd
+++ b/man/sce_to_anndata.Rd
@@ -22,7 +22,9 @@ Convert SingleCellExperiment objects to AnnData file stored as HDF5 file
 }
 \examples{
 \dontrun{
-sce_to_anndata(sce = sce_object,
-               anndata_file = "test_anndata.h5")
+sce_to_anndata(
+  sce = sce_object,
+  anndata_file = "test_anndata.h5"
+)
 }
 }

--- a/man/sim_sce.Rd
+++ b/man/sim_sce.Rd
@@ -24,7 +24,7 @@ Create a random SingleCellExperiment object
 }
 \examples{
 \dontrun{
-  sim_sce(n_genes = 100, n_cells = 100, n_empty = 2000, n_groups = 4)
+sim_sce(n_genes = 100, n_cells = 100, n_empty = 2000, n_groups = 4)
 }
 
 }


### PR DESCRIPTION
So it looked like having an Rprofile made the documentation part of the GHA fail, so I am adding a step to remove that file before setting up R and dependencies. Note that the deletion of that file is not part of the changes that are added before the commit, so that should be just a temporary change local to the action run.

Will try to  test to see if this works before requesting a reviewer, but may run into challenges.