### PR TITLE
Add tests for `cluster_sce` function

### DIFF
--- a/R/cluster_sce.R
+++ b/R/cluster_sce.R
@@ -29,6 +29,11 @@ cluster_sce <- function(sce,
   # Set the seed
   set.seed(seed)
 
+  # Check that provided sce is indeed an SCE
+  if (!is(sce, "SingleCellExperiment")) {
+    stop("Expected a `SingleCellExperiment` object for `sce` argument.")
+  }
+
   # Check that the PCs are present in the SingleCellExperiment object
   if (!pc_name %in% reducedDimNames(sce)) {
     stop("The provided `pc_name` cannot be found in the reduced dimensions of

--- a/R/cluster_sce.R
+++ b/R/cluster_sce.R
@@ -1,7 +1,7 @@
 #' Perform clustering on a SingleCellExperiment object
 #'
 #' @param sce SingleCellExperiment object that requires clustering
-#' @param pca_name The name used to access the PCA results stored in the
+#' @param pc_name The name used to access the PCA results stored in the
 #'   SingleCellExperiment object; default is "PCA"
 #' @param BLUSPARAM A BlusterParam object specifying the clustering algorithm to
 #'   use and any additional clustering options
@@ -21,7 +21,7 @@
 #'   cluster_sce(sce, "PCA", bluster::KmeansParam(centers = 10), "kmeans_10")
 #'  }
 cluster_sce <- function(sce,
-                        pca_name = "PCA",
+                        pc_name = "PCA",
                         BLUSPARAM,
                         cluster_column_name,
                         seed = NULL,
@@ -30,13 +30,13 @@ cluster_sce <- function(sce,
   set.seed(seed)
 
   # Check that the PCs are present in the SingleCellExperiment object
-  if (!pca_name %in% reducedDimNames(sce)) {
-    stop("The provided `pca_name` cannot be found in the reduced dimensions of
+  if (!pc_name %in% reducedDimNames(sce)) {
+    stop("The provided `pc_name` cannot be found in the reduced dimensions of
          the SingleCellExperiment object.")
   }
 
   # Extract PCs
-  pcs <- reducedDim(sce, pca_name)
+  pcs <- reducedDim(sce, pc_name)
   clustering_results <- bluster::clusterRows(pcs, BLUSPARAM, ...)
   sce[[cluster_column_name]] <- clustering_results
 

--- a/man/cluster_sce.Rd
+++ b/man/cluster_sce.Rd
@@ -6,7 +6,7 @@
 \usage{
 cluster_sce(
   sce,
-  pca_name = "PCA",
+  pc_name = "PCA",
   BLUSPARAM,
   cluster_column_name,
   seed = NULL,
@@ -16,7 +16,7 @@ cluster_sce(
 \arguments{
 \item{sce}{SingleCellExperiment object that requires clustering}
 
-\item{pca_name}{The name used to access the PCA results stored in the
+\item{pc_name}{The name used to access the PCA results stored in the
 SingleCellExperiment object; default is "PCA"}
 
 \item{BLUSPARAM}{A BlusterParam object specifying the clustering algorithm to

--- a/tests/testthat/test-cluster_sce.R
+++ b/tests/testthat/test-cluster_sce.R
@@ -21,6 +21,12 @@ test_that("cluster_sce function works when correctly specified", {
 test_that("cluster_sce function should fail when inputs incorrectly specified", {
 
   expect_error(
+    cluster_sce("not an sce object",
+                BLUSPARAM = blus_param,
+                cluster_column_name = cluster_colname)
+  )
+
+  expect_error(
     cluster_sce(sce,
                 pc_name = "definitely not the PCA name",
                 BLUSPARAM = blus_param,

--- a/tests/testthat/test-cluster_sce.R
+++ b/tests/testthat/test-cluster_sce.R
@@ -1,0 +1,41 @@
+# Establish testing data
+set.seed(27)
+sce <- sim_sce(n_genes = 20, n_cells = 100, n_empty = 0)
+reducedDim(sce, "PCA") <- matrix(runif(20 * 100, min = 0, max = 100), nrow = 100)
+cluster_colname <- "clustered_results"
+blus_param <- bluster::KmeansParam(centers = 10)
+
+
+test_that("cluster_sce function works when correctly specified", {
+
+  sce_clustered <- cluster_sce(sce,
+                               BLUSPARAM = blus_param,
+                               cluster_column_name = cluster_colname)
+
+  # Does the output look as expected?
+  expect_true(cluster_colname %in% names(colData(sce_clustered)))
+  expect_equal(levels(sce_clustered[[cluster_colname]]),
+               as.character(1:10))
+})
+
+test_that("cluster_sce function should fail when inputs incorrectly specified", {
+
+  expect_error(
+    cluster_sce(sce,
+                pc_name = "definitely not the PCA name",
+                BLUSPARAM = blus_param,
+                cluster_column_name = cluster_colname)
+  )
+
+  expect_error(
+    cluster_sce(sce,
+                BLUSPARAM = "not a bluster param",
+                cluster_column_name = cluster_colname)
+  )
+
+  expect_error(
+    cluster_sce(sce,
+                BLUSPARAM = blus_param)
+  )
+
+})


### PR DESCRIPTION
Closes #192 

This PR adds (passing :tada:) tests for the new `cluster_sce()` function, including tests that output is as expected when function is correctly used, and tests that the function errors when it should.
Some context - these tests were written as paired programming session w/ @cbethell. During this, we discussed how writing tests can help you find areas where the code itself can be made more robust. As an example of how one could do that, we added another check to `cluster_sce` that the input SCE is indeed an SCE, and wrote a unit test accordingly.

I also took this time to change the argument `pca_name` -> `pc_name`, which was mentioned here: https://github.com/AlexsLemonade/scpcaTools/pull/191#pullrequestreview-1547979343. 

Let me know if there are other tests that would be good to add! 