### PR TITLE
Fix within-batch ARI function

### DIFF
--- a/man/within_batch_ari_from_pcs.Rd
+++ b/man/within_batch_ari_from_pcs.Rd
@@ -5,6 +5,7 @@
 \title{Calculate within-batch ARI using provided PCs for use in integration metric calculations}
 \usage{
 within_batch_ari_from_pcs(
+  individual_sce_list,
   merged_sce,
   pc_name,
   batch_column = "library_id",
@@ -13,6 +14,9 @@ within_batch_ari_from_pcs(
 )
 }
 \arguments{
+\item{individual_sce_list}{A named list of individual SCE objects. It is
+assumed these have a reduced dimension slot with principal components named "PCA".}
+
 \item{merged_sce}{The merged SCE object containing data from multiple batches}
 
 \item{pc_name}{The name used to access the PCA results stored in the


### PR DESCRIPTION
Upon an attempt to implement the `calculate_within_batch_ari()` function in downstream analyses, an error regarding the `batch_ids` object not being found was encountered.

This is because we currently refer to batch ids in the [outer/wrapper function](https://github.com/AlexsLemonade/scpcaTools/blob/47644e14efbb9d37db37c8e08324f53dc769763e/R/calculate_within_batch_ari.R#L41) without passing them to the internal function [where we use them](https://github.com/AlexsLemonade/scpcaTools/blob/47644e14efbb9d37db37c8e08324f53dc769763e/R/calculate_within_batch_ari.R#L113).

This PR fixes that error by moving the `batch_ids` definition to the internal function. The documentation has also been updated to reflect the change.