### PR TITLE
Integration metrics test functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Description: Tools for processing single cell data associated with the
 License: BSD_3_clause + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.2
+RoxygenNote: 7.2.3
 Depends:
     R (>= 4.2.0)
 Imports:

--- a/R/calculate_within_batch_ari.R
+++ b/R/calculate_within_batch_ari.R
@@ -10,7 +10,7 @@
 #' @param batch_column The variable in `merged_sce` indicating the grouping of interest.
 #'  Generally this is either batches or cell types. Default is "library_id".
 #' @param barcode_column The variable in `merged_sce` indicating the original cell barcode.
-#'  Default is "barcode".
+#'  Default is "cell_id".
 #' @param BLUSPARAM A BlusterParam object specifying the clustering algorithm to
 #'   use and any additional clustering options. Default is
 #'   `bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard")`
@@ -29,7 +29,7 @@ calculate_within_batch_ari <- function(individual_sce_list,
                                        pc_names,
                                        merged_sce,
                                        batch_column = "library_id",
-                                       barcode_column = "barcode",
+                                       barcode_column = "cell_id",
                                        BLUSPARAM = bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard"),
                                        seed = NULL,
                                        ...) {
@@ -82,7 +82,7 @@ calculate_within_batch_ari <- function(individual_sce_list,
 #' @param batch_column The variable in `merged_sce` indicating the grouping of interest.
 #'  Generally this is either batches or cell types. Default is "library_id".
 #' @param barcode_column The variable in `merged_sce` indicating the original cell barcode.
-#'  Default is "barcode".
+#'  Default is "cell_id".
 #' @param BLUSPARAM A BlusterParam object specifying the clustering algorithm to
 #'   use and any additional clustering options. Default is
 #'   `bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard")`
@@ -96,7 +96,7 @@ within_batch_ari_from_pcs <-
            merged_sce,
            pc_name,
            batch_column = "library_id",
-           barcode_column = "barcode",
+           barcode_column = "cell_id",
            BLUSPARAM = bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard"),
            ...) {
 

--- a/R/calculate_within_batch_ari.R
+++ b/R/calculate_within_batch_ari.R
@@ -3,6 +3,7 @@
 #'
 #' @param individual_sce_list A named list of individual SCE objects. It is
 #'  assumed these have a reduced dimension slot with principal components named "PCA".
+#'  Column names of each object should match the contents of the `barcode_column` for the `merged_sce.`
 #' @param pc_names A list of names of the PCs in the merged SCE `reducedDim` slot
 #'  object. Example: c("PCA", "fastMNN_PCA"). A within-batch ARI will be returned for each `pc_name`.
 #' @param merged_sce The merged SCE object containing data from multiple batches
@@ -74,6 +75,7 @@ calculate_within_batch_ari <- function(individual_sce_list,
 #'
 #' @param individual_sce_list A named list of individual SCE objects. It is
 #'  assumed these have a reduced dimension slot with principal components named "PCA".
+#'  Column names of each object should match the contents of the `barcode_column` for the `merged_sce.`
 #' @param merged_sce The merged SCE object containing data from multiple batches
 #' @param pc_name The name used to access the PCA results stored in the
 #'   SingleCellExperiment object

--- a/R/calculate_within_batch_ari.R
+++ b/R/calculate_within_batch_ari.R
@@ -3,13 +3,13 @@
 #'
 #' @param individual_sce_list A named list of individual SCE objects. It is
 #'  assumed these have a reduced dimension slot with principal components named "PCA".
-#'  Column names of each object should match the contents of the `barcode_column` for the `merged_sce.`
+#'  Column names of each object should match the contents of the `cell_id_column` for the `merged_sce.`
 #' @param pc_names A list of names of the PCs in the merged SCE `reducedDim` slot
 #'  object. Example: c("PCA", "fastMNN_PCA"). A within-batch ARI will be returned for each `pc_name`.
 #' @param merged_sce The merged SCE object containing data from multiple batches
 #' @param batch_column The variable in `merged_sce` indicating the grouping of interest.
 #'  Generally this is either batches or cell types. Default is "library_id".
-#' @param barcode_column The variable in `merged_sce` indicating the original cell barcode.
+#' @param cell_id_column The variable in `merged_sce` indicating the original cell barcode.
 #'  Default is "cell_id".
 #' @param BLUSPARAM A BlusterParam object specifying the clustering algorithm to
 #'   use and any additional clustering options. Default is
@@ -29,7 +29,7 @@ calculate_within_batch_ari <- function(individual_sce_list,
                                        pc_names,
                                        merged_sce,
                                        batch_column = "library_id",
-                                       barcode_column = "cell_id",
+                                       cell_id_column = "cell_id",
                                        BLUSPARAM = bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard"),
                                        seed = NULL,
                                        ...) {
@@ -41,9 +41,9 @@ calculate_within_batch_ari <- function(individual_sce_list,
     stop("The specified batch column is missing from the colData of the `merged_sce`.")
   }
 
-  # Check that `barcode_column` is in colData of SCE
-  if (!barcode_column %in% colnames(colData(merged_sce))) {
-    stop("The specified barcode column is missing from the colData of the `merged_sce`.")
+  # Check that `cell_id_column` is in colData of SCE
+  if (!cell_id_column %in% colnames(colData(merged_sce))) {
+    stop("The specified cell id column is missing from the colData of the `merged_sce`.")
   }
 
 
@@ -61,7 +61,7 @@ calculate_within_batch_ari <- function(individual_sce_list,
         individual_sce_list = individual_sce_list,
         merged_sce = merged_sce,
         batch_column = batch_column,
-        barcode_column = barcode_column,
+        cell_id_column = cell_id_column,
         pc_name = pcs,
         BLUSPARAM = BLUSPARAM
       )
@@ -75,13 +75,13 @@ calculate_within_batch_ari <- function(individual_sce_list,
 #'
 #' @param individual_sce_list A named list of individual SCE objects. It is
 #'  assumed these have a reduced dimension slot with principal components named "PCA".
-#'  Column names of each object should match the contents of the `barcode_column` for the `merged_sce.`
+#'  Column names of each object should match the contents of the `cell_id_column` for the `merged_sce.`
 #' @param merged_sce The merged SCE object containing data from multiple batches
 #' @param pc_name The name used to access the PCA results stored in the
 #'   SingleCellExperiment object
 #' @param batch_column The variable in `merged_sce` indicating the grouping of interest.
 #'  Generally this is either batches or cell types. Default is "library_id".
-#' @param barcode_column The variable in `merged_sce` indicating the original cell barcode.
+#' @param cell_id_column The variable in `merged_sce` indicating the original cell barcode.
 #'  Default is "cell_id".
 #' @param BLUSPARAM A BlusterParam object specifying the clustering algorithm to
 #'   use and any additional clustering options. Default is
@@ -96,7 +96,7 @@ within_batch_ari_from_pcs <-
            merged_sce,
            pc_name,
            batch_column = "library_id",
-           barcode_column = "cell_id",
+           cell_id_column = "cell_id",
            BLUSPARAM = bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard"),
            ...) {
 
@@ -148,7 +148,7 @@ within_batch_ari_from_pcs <-
 
           # Extract cells from merged clustering for batch
           merged_clusters <- merged_sce$merged_clusters |>
-            purrr::set_names(colData(merged_sce)[[barcode_column]])
+            purrr::set_names(colData(merged_sce)[[cell_id_column]])
           cells_to_keep <- which(merged_sce[[batch_column]] == batch)
           batch_merged_clusters <- merged_clusters[cells_to_keep]
 

--- a/man/calculate_within_batch_ari.Rd
+++ b/man/calculate_within_batch_ari.Rd
@@ -9,6 +9,7 @@ calculate_within_batch_ari(
   pc_names,
   merged_sce,
   batch_column = "library_id",
+  barcode_column = "barcode",
   BLUSPARAM = bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard"),
   seed = NULL,
   ...
@@ -25,6 +26,9 @@ object. Example: c("PCA", "fastMNN_PCA"). A within-batch ARI will be returned fo
 
 \item{batch_column}{The variable in `merged_sce` indicating the grouping of interest.
 Generally this is either batches or cell types. Default is "library_id".}
+
+\item{barcode_column}{The variable in `merged_sce` indicating the original cell barcode.
+Default is "barcode".}
 
 \item{BLUSPARAM}{A BlusterParam object specifying the clustering algorithm to
 use and any additional clustering options. Default is

--- a/man/calculate_within_batch_ari.Rd
+++ b/man/calculate_within_batch_ari.Rd
@@ -9,7 +9,7 @@ calculate_within_batch_ari(
   pc_names,
   merged_sce,
   batch_column = "library_id",
-  barcode_column = "cell_id",
+  cell_id_column = "cell_id",
   BLUSPARAM = bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard"),
   seed = NULL,
   ...
@@ -18,7 +18,7 @@ calculate_within_batch_ari(
 \arguments{
 \item{individual_sce_list}{A named list of individual SCE objects. It is
 assumed these have a reduced dimension slot with principal components named "PCA".
-Column names of each object should match the contents of the `barcode_column` for the `merged_sce.`}
+Column names of each object should match the contents of the `cell_id_column` for the `merged_sce.`}
 
 \item{pc_names}{A list of names of the PCs in the merged SCE `reducedDim` slot
 object. Example: c("PCA", "fastMNN_PCA"). A within-batch ARI will be returned for each `pc_name`.}
@@ -28,7 +28,7 @@ object. Example: c("PCA", "fastMNN_PCA"). A within-batch ARI will be returned fo
 \item{batch_column}{The variable in `merged_sce` indicating the grouping of interest.
 Generally this is either batches or cell types. Default is "library_id".}
 
-\item{barcode_column}{The variable in `merged_sce` indicating the original cell barcode.
+\item{cell_id_column}{The variable in `merged_sce` indicating the original cell barcode.
 Default is "cell_id".}
 
 \item{BLUSPARAM}{A BlusterParam object specifying the clustering algorithm to

--- a/man/calculate_within_batch_ari.Rd
+++ b/man/calculate_within_batch_ari.Rd
@@ -9,7 +9,7 @@ calculate_within_batch_ari(
   pc_names,
   merged_sce,
   batch_column = "library_id",
-  barcode_column = "barcode",
+  barcode_column = "cell_id",
   BLUSPARAM = bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard"),
   seed = NULL,
   ...
@@ -29,7 +29,7 @@ object. Example: c("PCA", "fastMNN_PCA"). A within-batch ARI will be returned fo
 Generally this is either batches or cell types. Default is "library_id".}
 
 \item{barcode_column}{The variable in `merged_sce` indicating the original cell barcode.
-Default is "barcode".}
+Default is "cell_id".}
 
 \item{BLUSPARAM}{A BlusterParam object specifying the clustering algorithm to
 use and any additional clustering options. Default is

--- a/man/calculate_within_batch_ari.Rd
+++ b/man/calculate_within_batch_ari.Rd
@@ -17,7 +17,8 @@ calculate_within_batch_ari(
 }
 \arguments{
 \item{individual_sce_list}{A named list of individual SCE objects. It is
-assumed these have a reduced dimension slot with principal components named "PCA".}
+assumed these have a reduced dimension slot with principal components named "PCA".
+Column names of each object should match the contents of the `barcode_column` for the `merged_sce.`}
 
 \item{pc_names}{A list of names of the PCs in the merged SCE `reducedDim` slot
 object. Example: c("PCA", "fastMNN_PCA"). A within-batch ARI will be returned for each `pc_name`.}

--- a/man/within_batch_ari_from_pcs.Rd
+++ b/man/within_batch_ari_from_pcs.Rd
@@ -9,6 +9,7 @@ within_batch_ari_from_pcs(
   merged_sce,
   pc_name,
   batch_column = "library_id",
+  barcode_column = "barcode",
   BLUSPARAM = bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard"),
   ...
 )
@@ -24,6 +25,9 @@ SingleCellExperiment object}
 
 \item{batch_column}{The variable in `merged_sce` indicating the grouping of interest.
 Generally this is either batches or cell types. Default is "library_id".}
+
+\item{barcode_column}{The variable in `merged_sce` indicating the original cell barcode.
+Default is "barcode".}
 
 \item{BLUSPARAM}{A BlusterParam object specifying the clustering algorithm to
 use and any additional clustering options. Default is

--- a/man/within_batch_ari_from_pcs.Rd
+++ b/man/within_batch_ari_from_pcs.Rd
@@ -16,7 +16,8 @@ within_batch_ari_from_pcs(
 }
 \arguments{
 \item{individual_sce_list}{A named list of individual SCE objects. It is
-assumed these have a reduced dimension slot with principal components named "PCA".}
+assumed these have a reduced dimension slot with principal components named "PCA".
+Column names of each object should match the contents of the `barcode_column` for the `merged_sce.`}
 
 \item{merged_sce}{The merged SCE object containing data from multiple batches}
 

--- a/man/within_batch_ari_from_pcs.Rd
+++ b/man/within_batch_ari_from_pcs.Rd
@@ -9,7 +9,7 @@ within_batch_ari_from_pcs(
   merged_sce,
   pc_name,
   batch_column = "library_id",
-  barcode_column = "cell_id",
+  cell_id_column = "cell_id",
   BLUSPARAM = bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard"),
   ...
 )
@@ -17,7 +17,7 @@ within_batch_ari_from_pcs(
 \arguments{
 \item{individual_sce_list}{A named list of individual SCE objects. It is
 assumed these have a reduced dimension slot with principal components named "PCA".
-Column names of each object should match the contents of the `barcode_column` for the `merged_sce.`}
+Column names of each object should match the contents of the `cell_id_column` for the `merged_sce.`}
 
 \item{merged_sce}{The merged SCE object containing data from multiple batches}
 
@@ -27,7 +27,7 @@ SingleCellExperiment object}
 \item{batch_column}{The variable in `merged_sce` indicating the grouping of interest.
 Generally this is either batches or cell types. Default is "library_id".}
 
-\item{barcode_column}{The variable in `merged_sce` indicating the original cell barcode.
+\item{cell_id_column}{The variable in `merged_sce` indicating the original cell barcode.
 Default is "cell_id".}
 
 \item{BLUSPARAM}{A BlusterParam object specifying the clustering algorithm to

--- a/man/within_batch_ari_from_pcs.Rd
+++ b/man/within_batch_ari_from_pcs.Rd
@@ -9,7 +9,7 @@ within_batch_ari_from_pcs(
   merged_sce,
   pc_name,
   batch_column = "library_id",
-  barcode_column = "barcode",
+  barcode_column = "cell_id",
   BLUSPARAM = bluster::NNGraphParam(cluster.fun = "louvain", type = "jaccard"),
   ...
 )
@@ -28,7 +28,7 @@ SingleCellExperiment object}
 Generally this is either batches or cell types. Default is "library_id".}
 
 \item{barcode_column}{The variable in `merged_sce` indicating the original cell barcode.
-Default is "barcode".}
+Default is "cell_id".}
 
 \item{BLUSPARAM}{A BlusterParam object specifying the clustering algorithm to
 use and any additional clustering options. Default is

--- a/tests/testthat/test-integration_metrics.R
+++ b/tests/testthat/test-integration_metrics.R
@@ -135,7 +135,7 @@ test_that("`within_batch_ari_from_pcs` works as expected", {
                                             merged_sce = merged_sce,
                                             pc_name = "PCA",
                                             batch_column = "sample",
-                                            barcode_column = "cell_id")
+                                            cell_id_column = "cell_id")
 
   expected_cols <- c(
     "ari", "batch_id", "pc_name"
@@ -158,7 +158,7 @@ test_that("`within_batch_ari_from_pcs`fails as expected", {
                                          merged_sce = merged_sce,
                                          pc_name = "test_PC",
                                          batch_column = "sample",
-                                         barcode_column = "cell_id"))
+                                         cell_id_column = "cell_id"))
 
 
   # incorrect batch labels
@@ -166,13 +166,13 @@ test_that("`within_batch_ari_from_pcs`fails as expected", {
                                          merged_sce = merged_sce,
                                          pc_name = "PCA",
                                          batch_column = "batch",
-                                         barcode_column = "cell_id"))
+                                         cell_id_column = "cell_id"))
   # incorrect barcode label
   expect_error(within_batch_ari_from_pcs(individual_sce_list = sce_list,
                                          merged_sce = merged_sce,
                                          pc_name = "PCA",
                                          batch_column = "sample",
-                                         barcode_column = "not a barcode"))
+                                         cell_id_column = "not a barcode"))
 
   ## missing names for sce list
   # save to a new variable so we can use the sce list again later
@@ -183,7 +183,7 @@ test_that("`within_batch_ari_from_pcs`fails as expected", {
                                          merged_sce = merged_sce,
                                          pc_name = "PCA",
                                          batch_column = "sample",
-                                         barcode_column = "cell_id"))
+                                         cell_id_column = "cell_id"))
 
 })
 
@@ -196,7 +196,7 @@ test_that("`calculate_within_batch_ari` works as expected", {
                                     merged_sce = merged_sce,
                                     pc_names = c("PCA", "fastMNN_PCA"),
                                     batch_column = "sample",
-                                    barcode_column = "cell_id")
+                                    cell_id_column = "cell_id")
 
   expected_cols <- c(
     "ari", "batch_id", "pc_name"
@@ -219,7 +219,7 @@ test_that("`calculate_within_batch_ari`fails as expected", {
                                           merged_sce = merged_sce,
                                           pc_names = "test_PC",
                                           batch_column = "sample",
-                                          barcode_column = "cell_id"))
+                                          cell_id_column = "cell_id"))
 
 
   # incorrect batch labels
@@ -227,14 +227,14 @@ test_that("`calculate_within_batch_ari`fails as expected", {
                                          merged_sce = merged_sce,
                                          pc_names = c("PCA", "fastMNN_PCA"),
                                          batch_column = "batch",
-                                         barcode_column = "cell_id"))
+                                         cell_id_column = "cell_id"))
 
   # incorrect barcode labels
   expect_error(within_batch_ari_from_pcs(individual_sce_list = sce_list,
                                          merged_sce = merged_sce,
                                          pc_names = c("PCA", "fastMNN_PCA"),
                                          batch_column = "sample",
-                                         barcode_column = "not a barcode"))
+                                         cell_id_column = "not a barcode"))
 
 })
 

--- a/tests/testthat/test-integration_metrics.R
+++ b/tests/testthat/test-integration_metrics.R
@@ -11,7 +11,7 @@ rownames(colData(merged_sce)) <- new_rownames
 # Add "sample" to colData
 colData(merged_sce)$sample <- batches
 # add barcode to colData
-colData(merged_sce)$barcode <- barcodes
+colData(merged_sce)$cell_id <- barcodes
 
 # add PCs for testing (exact numbers don't matter)
 # make a 300x100 matrix
@@ -135,7 +135,7 @@ test_that("`within_batch_ari_from_pcs` works as expected", {
                                             merged_sce = merged_sce,
                                             pc_name = "PCA",
                                             batch_column = "sample",
-                                            barcode_column = "barcode")
+                                            barcode_column = "cell_id")
 
   expected_cols <- c(
     "ari", "batch_id", "pc_name"
@@ -158,7 +158,7 @@ test_that("`within_batch_ari_from_pcs`fails as expected", {
                                          merged_sce = merged_sce,
                                          pc_name = "test_PC",
                                          batch_column = "sample",
-                                         barcode_column = "barcode"))
+                                         barcode_column = "cell_id"))
 
 
   # incorrect batch labels
@@ -166,7 +166,7 @@ test_that("`within_batch_ari_from_pcs`fails as expected", {
                                          merged_sce = merged_sce,
                                          pc_name = "PCA",
                                          batch_column = "batch",
-                                         barcode_column = "barcode"))
+                                         barcode_column = "cell_id"))
   # incorrect barcode label
   expect_error(within_batch_ari_from_pcs(individual_sce_list = sce_list,
                                          merged_sce = merged_sce,
@@ -183,7 +183,7 @@ test_that("`within_batch_ari_from_pcs`fails as expected", {
                                          merged_sce = merged_sce,
                                          pc_name = "PCA",
                                          batch_column = "sample",
-                                         barcode_column = "barcode"))
+                                         barcode_column = "cell_id"))
 
 })
 
@@ -196,7 +196,7 @@ test_that("`calculate_within_batch_ari` works as expected", {
                                     merged_sce = merged_sce,
                                     pc_names = c("PCA", "fastMNN_PCA"),
                                     batch_column = "sample",
-                                    barcode_column = "barcode")
+                                    barcode_column = "cell_id")
 
   expected_cols <- c(
     "ari", "batch_id", "pc_name"
@@ -219,7 +219,7 @@ test_that("`calculate_within_batch_ari`fails as expected", {
                                           merged_sce = merged_sce,
                                           pc_names = "test_PC",
                                           batch_column = "sample",
-                                          barcode_column = "barcode"))
+                                          barcode_column = "cell_id"))
 
 
   # incorrect batch labels
@@ -227,7 +227,7 @@ test_that("`calculate_within_batch_ari`fails as expected", {
                                          merged_sce = merged_sce,
                                          pc_names = c("PCA", "fastMNN_PCA"),
                                          batch_column = "batch",
-                                         barcode_column = "barcode"))
+                                         barcode_column = "cell_id"))
 
   # incorrect barcode labels
   expect_error(within_batch_ari_from_pcs(individual_sce_list = sce_list,

--- a/tests/testthat/test-integration_metrics.R
+++ b/tests/testthat/test-integration_metrics.R
@@ -10,14 +10,20 @@ rownames(colData(merged_sce)) <- new_rownames
 
 # Add "sample" to colData
 colData(merged_sce)$sample <- batches
+# add barcode to colData
+colData(merged_sce)$barcode <- barcodes
 
 # add PCs for testing (exact numbers don't matter)
 # make a 300x100 matrix
 reducedDim(merged_sce, "PCA") <- matrix(runif(303 * 100, min = 0, max = 100), nrow = 303)
+rownames(reducedDim(merged_sce, "PCA")) <- colnames(merged_sce)
 
 # grab pcs and batches
 pcs <- reducedDim(merged_sce, "PCA")
 batches <- merged_sce$sample
+
+# create list of sce objects
+sce_list <- split(merged_sce, colData(merged_sce)$sample)
 
 test_that("`filter_pcs` works as expected", {
   # expect rownames of returned pcs to be the same as the batch column
@@ -113,4 +119,144 @@ test_that("`calculate_silhouette_width`fails as expected", {
     pc_names = "PCA",
     batch_column = "batch"
   ))
+})
+
+test_that("`within_batch_ari_from_pcs` works as expected", {
+
+  ari_from_pcs <- within_batch_ari_from_pcs(individual_sce_list = sce_list,
+                                            merged_sce = merged_sce,
+                                            pc_name = "PCA",
+                                            batch_column = "sample",
+                                            barcode_column = "barcode")
+
+  expected_cols <- c(
+    "ari", "batch_id", "pc_name"
+  )
+  # check column names
+  expect_true(all(expected_cols %in% colnames(ari_from_pcs)))
+
+  # check that pc name is PCA
+  expect_true(all(ari_from_pcs$pc_name == "PCA"))
+
+  # check that ari is in expected range
+  expect_true(all(ari_from_pcs$ari >= 0 |
+                    ari_from_pcs$ari <= 1))
+})
+
+test_that("`within_batch_ari_from_pcs`fails as expected", {
+
+  # missing pc name
+  expect_error(within_batch_ari_from_pcs(individual_sce_list = sce_list,
+                                         merged_sce = merged_sce,
+                                         pc_name = "test_PC",
+                                         batch_column = "sample",
+                                         barcode_column = "barcode"))
+
+
+  # incorrect batch labels
+  expect_error(within_batch_ari_from_pcs(individual_sce_list = sce_list,
+                                         merged_sce = merged_sce,
+                                         pc_name = "PCA",
+                                         batch_column = "batch",
+                                         barcode_column = "barcode"))
+  # incorrect barcode label
+  expect_error(within_batch_ari_from_pcs(individual_sce_list = sce_list,
+                                         merged_sce = merged_sce,
+                                         pc_name = "PCA",
+                                         batch_column = "sample",
+                                         barcode_column = "not a barcode"))
+
+  ## missing names for sce list
+  # save to a new variable so we can use the sce list again later
+  unnamed_sce_list <- sce_list
+  names(unnamed_sce_list) <- NULL
+
+  expect_error(within_batch_ari_from_pcs(individual_sce_list = sce_list,
+                                         merged_sce = merged_sce,
+                                         pc_name = "PCA",
+                                         batch_column = "sample",
+                                         barcode_column = "barcode"))
+
+})
+
+test_that("`calculate_within_batch_ari` works as expected", {
+
+  # add fastmnn pca to test multiple pcs
+  reducedDim(merged_sce, "fastMNN_PCA") <- matrix(runif(303 * 100, min = 0, max = 100), nrow = 303)
+
+  ari <- calculate_within_batch_ari(individual_sce_list = sce_list,
+                                    merged_sce = merged_sce,
+                                    pc_names = c("PCA", "fastMNN_PCA"),
+                                    batch_column = "sample",
+                                    barcode_column = "barcode")
+
+  expected_cols <- c(
+    "ari", "batch_id", "pc_name"
+  )
+  # check column names
+  expect_true(all(expected_cols %in% colnames(ari)))
+
+  # check that pc name is PCA
+  expect_true(all(ari$pc_name %in% c("PCA", "fastMNN_PCA")))
+
+  # check that ari is in expected range
+  expect_true(all(ari$ari >= 0 |
+                    ari$ari <= 1))
+})
+
+test_that("`calculate_within_batch_ari`fails as expected", {
+
+  # missing pc name
+  expect_error(calculate_within_batch_ari(individual_sce_list = sce_list,
+                                          merged_sce = merged_sce,
+                                          pc_names = "test_PC",
+                                          batch_column = "sample",
+                                          barcode_column = "barcode"))
+
+
+  # incorrect batch labels
+  expect_error(within_batch_ari_from_pcs(individual_sce_list = sce_list,
+                                         merged_sce = merged_sce,
+                                         pc_names = c("PCA", "fastMNN_PCA"),
+                                         batch_column = "batch",
+                                         barcode_column = "barcode"))
+
+  # incorrect barcode labels
+  expect_error(within_batch_ari_from_pcs(individual_sce_list = sce_list,
+                                         merged_sce = merged_sce,
+                                         pc_names = c("PCA", "fastMNN_PCA"),
+                                         batch_column = "sample",
+                                         barcode_column = "not a barcode"))
+
+})
+
+test_that("`calculate_ilisi` works as expected", {
+
+  ilisi <- calculate_ilisi(merged_sce = merged_sce,
+                           pc_name = "PCA",
+                           batch_column = "sample")
+
+  expected_cols <- c(
+    "ilisi_score", "cell_barcode", "batch_id"
+  )
+  # check column names
+  expect_true(all(expected_cols %in% colnames(ilisi)))
+
+  # check that ilisi is in expected range
+  expect_true(all(ilisi$ilisi_score >= 0 |
+                    ilisi$ilisi_score <= 1))
+})
+
+test_that("`calculate_ilisi` fails as expected", {
+
+  # fails with missing PC name
+  expect_error(calculate_ilisi(merged_sce = merged_sce,
+                               pc_name = "test_PC",
+                               batch_column = "sample"))
+
+  # fails with incorrect batch column
+  expect_error(calculate_ilisi(merged_sce = merged_sce,
+                               pc_name = "PCA",
+                               batch_column = "library_id"))
+
 })


### PR DESCRIPTION
Closes #194 and #197 

This PR adds test functions for both within batch ARI and the iLisi functions we recently added. In doing this I noticed that we had hard coded the column name that contains the original cell barcode in the `merged_sce`. So I went ahead and removed that hard coding and added a `barcode_column` argument. 

Are there any tests that I missed or should be checking? 