### PR TITLE
Fix iLISI calculation and test

### DIFF
--- a/man/calculate_ilisi.Rd
+++ b/man/calculate_ilisi.Rd
@@ -16,7 +16,8 @@ Generally this is either batches or cell types. Default is "library_id".}
 }
 \value{
 Data frame with three columns, one row per cell. Columns are `ilisi_score`,
-  `cell_barcode`, and `batch_id`
+ `ilisi_score_norm`, `cell_barcode`, and `batch_id`. The column `ilisi_score_norm`
+ is a normalized version if `ilisi_score` where values range from [0,1], inclusive
 }
 \description{
 Calculate iLISI (integration Local Inverse Simpson's Index) scores

--- a/tests/testthat/test-integration_metrics.R
+++ b/tests/testthat/test-integration_metrics.R
@@ -245,14 +245,17 @@ test_that("`calculate_ilisi` works as expected", {
                            batch_column = "sample")
 
   expected_cols <- c(
-    "ilisi_score", "cell_barcode", "batch_id"
+    "ilisi_score", "cell_barcode", "batch_id", "ilisi_score_norm"
   )
   # check column names
   expect_true(all(expected_cols %in% colnames(ilisi)))
 
-  # check that ilisi is in expected range
-  expect_true(all(ilisi$ilisi_score >= 0 |
-                    ilisi$ilisi_score <= 1))
+  # check that normalized ilisi scores are in in expected range
+  expect_true(
+    all(
+      dplyr::between(ilisi$ilisi_score_norm, 0, 1)
+    )
+  )
 })
 
 test_that("`calculate_ilisi` fails as expected", {


### PR DESCRIPTION
Closes #205 

This PR fixes iLISI as explained in the linked issue.

One choice I made here is to keep _both_ the raw ilisi score and the normalized version, saved in `ilisi_score_norm`. Then in the tests, I test that `ilisi_score_norm` is in the correct range. So, a question is do we actually foresee needing to keep the raw `ilisi_score` itself? It can be back-calculated from the normalized score if we wanted, so technically we don't _need_ both columns. What do reviewers think?