### PR TITLE
Update ARI function and ARI test

### DIFF
--- a/R/calculate_within_batch_ari.R
+++ b/R/calculate_within_batch_ari.R
@@ -134,7 +134,7 @@ within_batch_ari_from_pcs <-
 
     # For every batch id, cluster and then calculate ARI for that batch
     all_ari <-
-      purrr::map(
+      purrr::map_dbl(
         batch_ids,
         \(batch) {
           # Cluster pc matrix for specified batch

--- a/tests/testthat/test-integration_metrics.R
+++ b/tests/testthat/test-integration_metrics.R
@@ -104,8 +104,7 @@ test_that("`calculate_silhouette_width` works as expected", {
   expect_true(all(sort(unique(asw$rep)) == 1:nreps))
 
   # check that width is in expected range
-  expect_true(all(asw$silhouette_width >= -1 |
-    asw$silhouette_width <= 1))
+  expect_true(all(dplyr::between(asw$silhouette_width, -1, 1)))
 })
 
 test_that("`calculate_silhouette_width`fails as expected", {
@@ -147,8 +146,9 @@ test_that("`within_batch_ari_from_pcs` works as expected", {
   expect_true(all(ari_from_pcs$pc_name == "PCA"))
 
   # check that ari is in expected range
-  expect_true(all(ari_from_pcs$ari >= 0 |
-                    ari_from_pcs$ari <= 1))
+  expect_true(all(
+    dplyr::between(ari_from_pcs$ari, -1, 1)
+  ))
 })
 
 test_that("`within_batch_ari_from_pcs`fails as expected", {
@@ -192,7 +192,7 @@ test_that("`calculate_within_batch_ari` works as expected", {
   # add fastmnn pca to test multiple pcs
   reducedDim(merged_sce, "fastMNN_PCA") <- matrix(runif(303 * 100, min = 0, max = 100), nrow = 303)
 
-  ari <- calculate_within_batch_ari(individual_sce_list = sce_list,
+  ari <- scpcaTools::calculate_within_batch_ari(individual_sce_list = sce_list,
                                     merged_sce = merged_sce,
                                     pc_names = c("PCA", "fastMNN_PCA"),
                                     batch_column = "sample",
@@ -208,8 +208,9 @@ test_that("`calculate_within_batch_ari` works as expected", {
   expect_true(all(ari$pc_name %in% c("PCA", "fastMNN_PCA")))
 
   # check that ari is in expected range
-  expect_true(all(ari$ari >= 0 |
-                    ari$ari <= 1))
+  expect_true(all(
+    dplyr::between(ari$ari, -1, 1)
+  ))
 })
 
 test_that("`calculate_within_batch_ari`fails as expected", {


### PR DESCRIPTION
Inspired by #205, I decided to check up on the ARI tests and also change to using `dplyr::between()` for that. In doing that I realized we were returning a list for each ari in the dataframe, when we want each entry to be its own value. I changed the function to use `purrr::map_dbl` instead of `purrr::map`. 

@cbethell once this is fixed, you may want to make sure the hash is correct for downstream analyses and that nothing is broken in the report. 