### PR TITLE
Add Chanté as author to package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,6 +14,9 @@ Authors@R: c(
     person(c("Stephanie", "J."), "Spielman",
            email = "stephanie.spielman@ccdatalab.org",
            comment = list(ORCID = "0000-0002-9090-4788"),
+           role = c("aut")),
+    person(c("Chanté", "J."), "Bethell",
+           comment = list(ORCID = "0000-0001-9653-8128"),
            role = c("aut"))
     )
 Maintainer: Ally Hawkins <ally.hawkins@ccdatalab.org>
@@ -62,7 +65,7 @@ Suggests:
     Seurat,
     testthat (>= 3.0.0),
     zellkonverter
-Remotes: 
+Remotes:
     AlexsLemonade/scpcaData,
     github::immunogenomics/lisi
 Config/testthat/edition: 3


### PR DESCRIPTION
Closes #209 
Does what it says! Email indeed appears optional.

I've populated middle initial & ORCID based on records from OpenPBTA - 
https://github.com/AlexsLemonade/OpenPBTA-manuscript/blob/3ea2230ff09219840983349c8c53b344e56095ef/content/metadata.yaml#L90-L93

Edit - preview of ^:

```
- github: cbethell
  name: Chante J. Bethell
  initials: CJB
  orcid: 0000-0001-9653-8128
```