### PR TITLE
Add argument for assay name to use for X in AnnData object

### DIFF
--- a/R/sce_to_anndata.R
+++ b/R/sce_to_anndata.R
@@ -2,7 +2,7 @@
 #'
 #' @param sce SingleCellExperiment object to be converted to AnnData as an HDF5 file
 #' @param anndata_file Path to output AnnData file. Must be an `.h5` or `.hdf5`
-#' @param x_assay_name Name of assay in SCE object to save as X in AnnData
+#' @param x_assay_name Name of assay in SCE object to save as X in AnnData. Default is "counts".
 #'
 #' @return original SingleCellExperiment object used as input (invisibly)
 #' **Note that any columns present in the `rowData` of an SCE object that contains

--- a/R/sce_to_anndata.R
+++ b/R/sce_to_anndata.R
@@ -49,7 +49,8 @@ sce_to_anndata <- function(sce, anndata_file, x_assay_name = "counts") {
   }
 
   # export SCE object as AnnData to HDF5 file
-  zellkonverter::writeH5AD(sce_to_convert, file = anndata_file, X_name = x_assay_name)
-
+  zellkonverter::writeH5AD(sce_to_convert,
+                           file = anndata_file,
+                           X_name = x_assay_name)
   invisible(sce)
 }

--- a/R/sce_to_anndata.R
+++ b/R/sce_to_anndata.R
@@ -2,6 +2,7 @@
 #'
 #' @param sce SingleCellExperiment object to be converted to AnnData as an HDF5 file
 #' @param anndata_file Path to output AnnData file. Must be an `.h5` or `.hdf5`
+#' @param x_assay_name Name of assay in SCE object to save as X in AnnData
 #'
 #' @return original SingleCellExperiment object used as input (invisibly)
 #' **Note that any columns present in the `rowData` of an SCE object that contains
@@ -19,7 +20,7 @@
 #'   anndata_file = "test_anndata.h5"
 #' )
 #' }
-sce_to_anndata <- function(sce, anndata_file) {
+sce_to_anndata <- function(sce, anndata_file, x_assay_name = "counts") {
   if (!requireNamespace("zellkonverter", quietly = TRUE)) {
     stop("The zellkonverter package must be installed to convert objects to AnnData. No output file written.")
   }
@@ -33,6 +34,11 @@ sce_to_anndata <- function(sce, anndata_file) {
     stop("`anndata_file` must end in either '.hdf5' or '.h5'")
   }
 
+  # make sure assay is found in sce object
+  if(!x_assay_name %in% assayNames(sce)){
+    stop("`x_assay_name` is not an assay in `sce`")
+  }
+
   # assign SCE to new variable to avoid modifying input SCE
   sce_to_convert <- sce
 
@@ -43,7 +49,7 @@ sce_to_anndata <- function(sce, anndata_file) {
   }
 
   # export SCE object as AnnData to HDF5 file
-  zellkonverter::writeH5AD(sce_to_convert, file = anndata_file, X_name = "counts")
+  zellkonverter::writeH5AD(sce_to_convert, file = anndata_file, X_name = x_assay_name)
 
   invisible(sce)
 }

--- a/man/sce_to_anndata.Rd
+++ b/man/sce_to_anndata.Rd
@@ -4,12 +4,14 @@
 \alias{sce_to_anndata}
 \title{Convert SingleCellExperiment objects to AnnData file stored as HDF5 file}
 \usage{
-sce_to_anndata(sce, anndata_file)
+sce_to_anndata(sce, anndata_file, x_assay_name = "counts")
 }
 \arguments{
 \item{sce}{SingleCellExperiment object to be converted to AnnData as an HDF5 file}
 
 \item{anndata_file}{Path to output AnnData file. Must be an `.h5` or `.hdf5`}
+
+\item{x_assay_name}{Name of assay in SCE object to save as X in AnnData}
 }
 \value{
 original SingleCellExperiment object used as input (invisibly)

--- a/man/sce_to_anndata.Rd
+++ b/man/sce_to_anndata.Rd
@@ -11,7 +11,7 @@ sce_to_anndata(sce, anndata_file, x_assay_name = "counts")
 
 \item{anndata_file}{Path to output AnnData file. Must be an `.h5` or `.hdf5`}
 
-\item{x_assay_name}{Name of assay in SCE object to save as X in AnnData}
+\item{x_assay_name}{Name of assay in SCE object to save as X in AnnData. Default is "counts".}
 }
 \value{
 original SingleCellExperiment object used as input (invisibly)

--- a/tests/testthat/test-sce_to_anndata.R
+++ b/tests/testthat/test-sce_to_anndata.R
@@ -26,7 +26,7 @@ test_that("Conversion of SCE to AnnData works as expected", {
   # test that H5 file is created with new assay name
   # add logcounts
   logcounts(sce) <- counts(sce)
-  new_anndata_file <- "test_anndata_logcounts.h5"
+  new_anndata_file <- tempfile(fileext = ".h5")
   expect_snapshot_file({
     sce_to_anndata(sce, new_anndata_file, x_assay_name = "logcounts")
     new_anndata_file
@@ -37,7 +37,7 @@ test_that("Conversion of SCE to AnnData works as expected", {
 test_that("Conversion of SCE to AnnData fails as expected", {
 
   # check that inputting an improper file name causes a failure
-  anndata_bad_file <- "test_anndata"
+  anndata_bad_file <- tempfile(fileext = ".rds")
   expect_error(sce_to_anndata(sce, anndata_bad_file))
 
   # improper assay name causes a failure

--- a/tests/testthat/test-sce_to_anndata.R
+++ b/tests/testthat/test-sce_to_anndata.R
@@ -3,10 +3,13 @@ sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 0)
 colData(sce) <- DataFrame("test_column" = sample(0:10, 100, rep = TRUE))
 rowData(sce) <- DataFrame("test_row" = sample(0:10, 200, rep = TRUE))
 
+# define anndata output
+anndata_file <- "test_anndata.h5"
+# quiet messages that will come with zellkonverter
+suppressPackageStartupMessages(library(zellkonverter))
+
+
 test_that("Conversion of SCE to AnnData works as expected", {
-  anndata_file <- "test_anndata.h5"
-  # quiet messages that will come with zellkonverter
-  suppressPackageStartupMessages(library(zellkonverter))
 
   # test that the H5 file is created
   expect_snapshot_file({
@@ -20,7 +23,23 @@ test_that("Conversion of SCE to AnnData works as expected", {
   expect_equal(colnames(colData(sce)), colnames(colData(converted_sce)))
   expect_equal(colnames(rowData(sce)), colnames(rowData(converted_sce)))
 
+  # test that H5 file is created with new assay name
+  # add logcounts
+  logcounts(sce) <- counts(sce)
+  new_anndata_file <- "test_anndata_logcounts.h5"
+  expect_snapshot_file({
+    sce_to_anndata(sce, new_anndata_file, x_assay_name = "logcounts")
+    new_anndata_file
+  })
+
+})
+
+test_that("Conversion of SCE to AnnData fails as expected", {
+
   # check that inputting an improper file name causes a failure
   anndata_bad_file <- "test_anndata"
   expect_error(sce_to_anndata(sce, anndata_bad_file))
+
+  # improper assay name causes a failure
+  expect_error(sce_to_anndata(sce, anndata_file, x_assay_name = "not an assay"))
 })

--- a/tests/testthat/test-sce_to_anndata.R
+++ b/tests/testthat/test-sce_to_anndata.R
@@ -3,7 +3,9 @@ suppressPackageStartupMessages(library(zellkonverter))
 
 set.seed(1665)
 sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 0)
-colData(sce) <- DataFrame("test_column" = sample(0:10, 100, rep = TRUE))
+# need to pull out barcodes to add to colData, otherwise colnames get replaced with NULL
+barcodes <- colnames(sce)
+colData(sce) <- DataFrame("test_column" = sample(0:10, 100, rep = TRUE), row.names = barcodes)
 rowData(sce) <- DataFrame("test_row" = sample(0:10, 200, rep = TRUE))
 
 # define anndata output
@@ -32,17 +34,17 @@ test_that("Conversion of SCE to AnnData works as expected", {
     new_anndata_file
   })
 
-  converted_sce <- zellkonverter::readH5AD(new_anndata_file, X_name = "X")
+  new_sce <- zellkonverter::readH5AD(new_anndata_file, X_name = "X")
   # check that counts is in assay names and no logcounts
   expect_setequal(
-    assayNames(converted_sce),
-    c("X", "counts", "spliced")
+    assayNames(new_sce),
+    c("X", "counts")
   )
 
   # check that X is equal to logcounts
   expect_equal(
     logcounts(sce),
-    assay(converted_sce, "X")
+    assay(new_sce, "X")
   )
 
 })

--- a/tests/testthat/test-sce_to_anndata.R
+++ b/tests/testthat/test-sce_to_anndata.R
@@ -32,6 +32,19 @@ test_that("Conversion of SCE to AnnData works as expected", {
     new_anndata_file
   })
 
+  converted_sce <- zellkonverter::readH5AD(new_anndata_file)
+  # check that counts is in assay names and no logcounts
+  expect_setequal(
+    assayNames(converted_sce),
+    c("X", "counts", "spliced")
+  )
+
+  # check that X is equal to logcounts
+  expect_equal(
+    logcounts(sce),
+    assay(converted_sce, "X")
+  )
+
 })
 
 test_that("Conversion of SCE to AnnData fails as expected", {

--- a/tests/testthat/test-sce_to_anndata.R
+++ b/tests/testthat/test-sce_to_anndata.R
@@ -32,7 +32,7 @@ test_that("Conversion of SCE to AnnData works as expected", {
     new_anndata_file
   })
 
-  converted_sce <- zellkonverter::readH5AD(new_anndata_file)
+  converted_sce <- zellkonverter::readH5AD(new_anndata_file, X_name = "X")
   # check that counts is in assay names and no logcounts
   expect_setequal(
     assayNames(converted_sce),

--- a/tests/testthat/test-sce_to_anndata.R
+++ b/tests/testthat/test-sce_to_anndata.R
@@ -1,13 +1,13 @@
+# quiet messages that will come with zellkonverter
+suppressPackageStartupMessages(library(zellkonverter))
+
 set.seed(1665)
 sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 0)
 colData(sce) <- DataFrame("test_column" = sample(0:10, 100, rep = TRUE))
 rowData(sce) <- DataFrame("test_row" = sample(0:10, 200, rep = TRUE))
 
 # define anndata output
-anndata_file <- "test_anndata.h5"
-# quiet messages that will come with zellkonverter
-suppressPackageStartupMessages(library(zellkonverter))
-
+anndata_file <- tempfile(fileext = ".h5")
 
 test_that("Conversion of SCE to AnnData works as expected", {
 


### PR DESCRIPTION
Closes #218 

This PR adds a new argument to the function for converting SCE objects to AnnData, x_assay_name. This was pretty straight forward and I just passed the name to the zellkonverter function. 

I also updated the tests to check that it works with a different assay name and failed with an incorrect name. 

The only other thing I thought of here was trying to save an object with `logcounts` to the X assay and then `counts` to the `raw.X`. The only way to save things to `raw.X` is to use `raw=TRUE` with the zellkonverter function. When I try that, it doesn't save anything to the `X` assay even if you specify what to save. So I think for saving things to `raw.X` we will have to go in and directly modify the AnnData object after conversion. 