### PR TITLE
Preserve original colnames when adding the metadata to an object colData

### DIFF
--- a/R/metadata_to_coldata.R
+++ b/R/metadata_to_coldata.R
@@ -66,7 +66,7 @@ metadata_to_coldata <- function(sce,
 
   # replace existing coldata
   colData(sce) <- DataFrame(coldata_df,
-    row.names = rownames(coldata_df)
+    row.names = colnames(sce)
   )
 
   # return modified sce with sample metadata


### PR DESCRIPTION
In some testing of real objects, I noticed that the column names were getting replaced when we were running the `metadata_to_coldata` function. This was happening because when we do the `left_join` with the `colData`, the row names get over-written. To account for that I decided to set the row names for `colData` directly from the col names of the SCE object. 