### PR TITLE
Add handling of NA_character_ columns for anndata export

### DIFF
--- a/R/sce_to_anndata.R
+++ b/R/sce_to_anndata.R
@@ -52,14 +52,14 @@ sce_to_anndata <- function(sce, anndata_file, x_assay_name = "counts") {
   colData(sce_to_convert) <- colData(sce_to_convert) |>
     as.data.frame() |>
     dplyr::mutate(
-      across(where(\(x) all(is.na(x))), as.logical)
+      dplyr::across(dplyr::where(\(x) all(is.na(x))), as.logical)
     ) |>
     DataFrame(row.names = colnames(sce_to_convert))
 
   rowData(sce_to_convert) <- rowData(sce_to_convert) |>
     as.data.frame() |>
     dplyr::mutate(
-      across(where(\(x) all(is.na(x))), as.logical)
+      dplyr::across(dplyr::where(\(x) all(is.na(x))), as.logical)
     ) |>
     DataFrame(row.names = rownames(sce_to_convert))
 

--- a/tests/testthat/test-sce_to_anndata.R
+++ b/tests/testthat/test-sce_to_anndata.R
@@ -5,7 +5,11 @@ set.seed(1665)
 sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 0)
 # need to pull out barcodes to add to colData, otherwise colnames get replaced with NULL
 barcodes <- colnames(sce)
-colData(sce) <- DataFrame("test_column" = sample(0:10, 100, rep = TRUE), row.names = barcodes)
+colData(sce) <- DataFrame("test_column" = sample(0:10, 100, rep = TRUE),
+                          "na_column" = NA,
+                          "na_char_column" = NA_character_,
+                          # "some_na" = c("a", NA),
+                          row.names = barcodes)
 rowData(sce) <- DataFrame("test_row" = sample(0:10, 200, rep = TRUE))
 
 # define anndata output

--- a/tests/testthat/test-sce_to_anndata.R
+++ b/tests/testthat/test-sce_to_anndata.R
@@ -8,12 +8,13 @@ barcodes <- colnames(sce)
 colData(sce) <- DataFrame("test_column" = sample(0:10, 100, rep = TRUE),
                           "na_column" = NA,
                           "na_char_column" = NA_character_,
-                          # "some_na" = c("a", NA),
+                          "some_na" = c("a", NA),
                           row.names = barcodes)
 rowData(sce) <- DataFrame("test_row" = sample(0:10, 200, rep = TRUE))
 
 # define anndata output
-anndata_file <- tempfile(fileext = ".h5")
+tempdir <- tempdir()
+anndata_file <- file.path(tempdir, "anndata.h5")
 
 test_that("Conversion of SCE to AnnData works as expected", {
 
@@ -32,7 +33,7 @@ test_that("Conversion of SCE to AnnData works as expected", {
   # test that H5 file is created with new assay name
   # add logcounts
   logcounts(sce) <- counts(sce)
-  new_anndata_file <- tempfile(fileext = ".h5")
+  new_anndata_file <- file.path(tempdir, "new_anndata.h5")
   expect_snapshot_file({
     sce_to_anndata(sce, new_anndata_file, x_assay_name = "logcounts")
     new_anndata_file


### PR DESCRIPTION
As seen in https://github.com/AlexsLemonade/scpca-nf/pull/453#issue-1896967770, we sometimes run into trouble with Anndata exports when a column is listed as a character column but is all `NA`.

This code should transform any columns in `colData` or `rowData` that are all NA to logical types before saving. I added tests to be sure that it is working as expected.

I confirmed that without the added code, the tests fail, but they pass with it.

In testing also realized that by using `tempfile()` we lose the snapshot features of `testthat`, so I am now using a temporary directory, but set file names. 