### PR TITLE
Fail conversion to AnnData if SCE object doesn't have enough cells

### DIFF
--- a/R/sce_to_anndata.R
+++ b/R/sce_to_anndata.R
@@ -29,6 +29,10 @@ sce_to_anndata <- function(sce, anndata_file, x_assay_name = "counts") {
     stop("Input must be a SingleCellExperiment object.")
   }
 
+  if(ncol(sce) < 2){
+    stop("Input SingleCellExperiment must at least 2 cells.")
+  }
+
   # check that filename is in the proper format for writing h5
   if (!(stringr::str_ends(anndata_file, ".hdf5|.h5"))) {
     stop("`anndata_file` must end in either '.hdf5' or '.h5'")

--- a/R/sce_to_anndata.R
+++ b/R/sce_to_anndata.R
@@ -30,7 +30,7 @@ sce_to_anndata <- function(sce, anndata_file, x_assay_name = "counts") {
   }
 
   if(ncol(sce) < 2){
-    stop("Input SingleCellExperiment must at least 2 cells.")
+    stop("Input SingleCellExperiment must contain at least 2 cells.")
   }
 
   # check that filename is in the proper format for writing h5

--- a/tests/testthat/test-sce_to_anndata.R
+++ b/tests/testthat/test-sce_to_anndata.R
@@ -62,4 +62,8 @@ test_that("Conversion of SCE to AnnData fails as expected", {
 
   # improper assay name causes a failure
   expect_error(sce_to_anndata(sce, anndata_file, x_assay_name = "not an assay"))
+
+  # conversion fails if < 2 cells
+  small_sce <- sce[, 1]
+  expect_error(sce_to_anndata(small_sce, anndata_file))
 })


### PR DESCRIPTION
Since we recently discovered you need at least 2 cells to create an AnnData object using zellkonverter, I thought it would be a good idea to have a check for the number of cells in `sce_to_anndata`. Here, if an object has < 2 cells, then an error is produced. 