### PR TITLE
Use Harmony 1.0

### DIFF
--- a/docker/renv.lock
+++ b/docker/renv.lock
@@ -903,6 +903,13 @@
       ],
       "Hash": "a8e668a6eff4127b6b5e72d02ca9b111"
     },
+    "RhpcBLASctl": {
+      "Package": "RhpcBLASctl",
+      "Version": "0.23-42",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Hash": "c966ea2957ff75e77afa5c908dfc89e1"
+    },
     "Rhtslib": {
       "Package": "Rhtslib",
       "Version": "2.2.0",
@@ -2459,7 +2466,7 @@
     },
     "harmony": {
       "Package": "harmony",
-      "Version": "0.1.1",
+      "Version": "1.0.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -2468,16 +2475,15 @@
         "Rcpp",
         "RcppArmadillo",
         "RcppProgress",
+        "RhpcBLASctl",
         "cowplot",
         "dplyr",
         "ggplot2",
-        "irlba",
         "methods",
         "rlang",
-        "tibble",
-        "tidyr"
+        "tibble"
       ],
-      "Hash": "0c5a19c351e5ce6b053b852cb88c312a"
+      "Hash": "ae92e686936589dec53b0514cff659f6"
     },
     "haven": {
       "Package": "haven",

--- a/man/integrate_harmony.Rd
+++ b/man/integrate_harmony.Rd
@@ -6,7 +6,14 @@
 approach from the `harmony` package.
 Source: https://cran.r-project.org/web/packages/harmony/index.html}
 \usage{
-integrate_harmony(merged_sce, batch_column, covariate_cols = c(), ...)
+integrate_harmony(
+  merged_sce,
+  batch_column,
+  covariate_cols = c(),
+  batch_lambda = 1,
+  covariate_lambda = c(),
+  ...
+)
 }
 \arguments{
 \item{merged_sce}{A merged SCE object as prepared by `scpcaTools::merge_sce_list()`.}
@@ -17,7 +24,13 @@ being integrated.}
 \item{covariate_cols}{A vector of other columns to consider as
 covariates during integration.}
 
-\item{...}{Additional arguments to pass into `harmony::HarmonyMatrix()`}
+\item{batch_lambda}{The ridge regression penalty to use when correcting using the `batch_column`.
+Default is 1.}
+
+\item{covariate_lambda}{A vector of ridge regression penalties to use with each covariate.
+A lambda value must be provided for each covariate column.}
+
+\item{...}{Additional arguments to pass into `harmony::RunHarmony()`}
 }
 \value{
 Integrated PCs as calculated by `harmony`

--- a/man/integrate_sces.Rd
+++ b/man/integrate_sces.Rd
@@ -13,6 +13,8 @@ integrate_sces(
   integration_method = c("fastMNN", "harmony"),
   batch_column = "sample",
   covariate_cols = c(),
+  batch_lambda = 1,
+  covariate_lambda = c(),
   return_corrected_expression = FALSE,
   seed = NULL,
   ...
@@ -29,6 +31,13 @@ integrate_sces(
 \item{covariate_cols}{A vector of additional columns in the merged SCE to
 consider as covariates during integration. Currently, this is used only by
 `harmony`.}
+
+\item{batch_lambda}{The ridge regression penalty to use when correcting using the `batch_column`.
+This is only used by `harmony`. Default is 1.}
+
+\item{covariate_lambda}{A vector of ridge regression penalties to use with each covariate.
+A lambda value must be provided for each covariate column.
+This is only used by `harmony`.}
 
 \item{return_corrected_expression}{A boolean indicating whether corrected expression
 values determined by the given integration method should be included in the

--- a/tests/testthat/test-integrate_sces.R
+++ b/tests/testthat/test-integrate_sces.R
@@ -92,6 +92,18 @@ test_that("`integrate_harmony` fails when covariate columns are missing", {
   )
 })
 
+test_that("`integrate_harmony` fails when covariates are provided but no covariate_lambda", {
+  expect_error(
+    integrate_sces(
+      merged_sce,
+      "harmony",
+      batch_column,
+      covariate_cols = "covariate"
+      # no covariate lambda provided
+    )
+  )
+})
+
 
 ################################################################################
 ################################################################################
@@ -165,7 +177,8 @@ test_that("`integrate_sces` works as expected for return_corrected_expression=TR
   # harmony should warn:
   expect_warning(
     # this needs to be saved to avoid `Error in x$.self$finalize() : attempt to apply non-function`
-    result <- integrate_sces(merged_sce,
+    result <- integrate_sces(
+      merged_sce,
       "harmony",
       return_corrected_expression = TRUE
     )
@@ -203,22 +216,24 @@ test_that("`integrate_sces` works as expected for harmony defaults", {
 
 test_that("`integrate_sces` works as expected with harmony extra arguments", {
   expect_no_error(
-    integrated_sce <- integrate_sces(merged_sce,
+    integrated_sce <- integrate_sces(
+      merged_sce,
       "harmony",
       batch_column,
-      lambda = 2
+      max_iter = 2
     )
   )
 })
-
-
 
 test_that("`integrate_sces` works as expected with a harmony covariate", {
   expect_no_error(
-    integrate_sces(merged_sce,
+    integrate_sces(
+      merged_sce,
       "harmony",
       batch_column,
-      covariate_cols = "covariate"
+      covariate_cols = "covariate",
+      covariate_lambda = 1
     )
   )
 })
+

--- a/tests/testthat/test-integrate_sces.R
+++ b/tests/testthat/test-integrate_sces.R
@@ -92,14 +92,14 @@ test_that("`integrate_harmony` fails when covariate columns are missing", {
   )
 })
 
-test_that("`integrate_harmony` fails when covariates are provided but no covariate_lambda", {
+test_that("`integrate_harmony` fails when covariates and covariate_lambda don't match up", {
   expect_error(
     integrate_sces(
       merged_sce,
       "harmony",
       batch_column,
-      covariate_cols = "covariate"
-      # no covariate lambda provided
+      covariate_cols = "covariate",
+      covariate_lambda = c(1,2) # 1 extra lambda
     )
   )
 })
@@ -226,6 +226,8 @@ test_that("`integrate_sces` works as expected with harmony extra arguments", {
 })
 
 test_that("`integrate_sces` works as expected with a harmony covariate", {
+
+  # first with providing lambda
   expect_no_error(
     integrate_sces(
       merged_sce,
@@ -235,5 +237,16 @@ test_that("`integrate_sces` works as expected with a harmony covariate", {
       covariate_lambda = 1
     )
   )
+
+  # now without providing lambda which will be determined automatically
+  expect_no_error(
+    integrate_sces(
+      merged_sce,
+      "harmony",
+      batch_column,
+      covariate_cols = "covariate"
+    )
+  )
+
 })
 


### PR DESCRIPTION
Stacked on #226 so that we avoid conflicts with package versions. 

Based on comments in #226, this updates the lock file to use [Harmony 1.0](https://cran.r-project.org/web/packages/harmony/harmony.pdf) and updates the integration functions to incorporate any changes. 

Harmony no longer includes `HarmonyMatrix`, which is the function that we were previously using to generate results. Instead, they now have just the main `RunHarmony` that can take as input the pca matrix, SCE, or Seurat object. I chose to use the version that inputs the pca matrix since that aligns with how we were previously handling things. 

The only major change was dealing with their `lambda` argument and matching that with how we use covariates. Basically, the number of covariates specified must match up with the number of `lambda` values provided. At a minimum, we will have one covariate, the `batch_column`, and that can use the default `lambda` value of 1 that's set in the function itself. 

However, if we add an additional covariate column to use, then the number of covariates is now 2 (batch + additional column), and we haven't required changing the `lambda`, so it's still just 1. That leads to a mismatch and an error when using `RunHarmony`. To combat this, I created two new arguments, `batch_lambda` and `covariate_lambda`. I thought it would be helpful to separate them since we will always need some sort of lambda vector whether or not we have covariates. 

Another option would be to have one lambda as an argument and then automatically set all the lambdas to be equal if covariates are present, but I don't know if we want to do that. That removes the flexibility of setting lambdas for batch vs other covariates separately, which is supported in the actual `RunHarmony` function. 

This passed my tests locally, so fingers crossed it works here too 🤞 