### PR TITLE
Remove objects and data frames from SCE metadata

### DIFF
--- a/R/sce_to_anndata.R
+++ b/R/sce_to_anndata.R
@@ -46,11 +46,22 @@ sce_to_anndata <- function(sce, anndata_file, x_assay_name = "counts") {
   # assign SCE to new variable to avoid modifying input SCE
   sce_to_convert <- sce
 
-  # remove miQC model from metadata
-  if (!is.null(metadata(sce_to_convert)$miQC_model)) {
-    metadata(sce_to_convert)$miQC_model <- NULL
-    message("miQC model cannot be converted between SCE and AnnData.")
+  # grab existing metadata
+  metadata_list <- metadata(sce_to_convert)
+
+  # remove any objects or dataframes
+  metadata_to_keep <- metadata_list |>
+    purrr::discard(is.object) |>
+    purrr::discard(is.data.frame)
+
+  # print out warning that removed objects won't be converted
+  removed_metadata <- names(metadata_list)[!names(metadata_list) %in% names(metadata_to_keep)]
+  if(length(removed_metadata) > 0){
+    glue::glue("{removed_metadata} cannot be converted between SCE and AnnData.")
   }
+
+  # reset metadata
+  metadata(sce_to_convert) <- metadata_to_keep
 
   # zellkonverter (or pandas) does not like NA values to be stored in character vectors
   colData(sce_to_convert) <- colData(sce_to_convert) |>

--- a/tests/testthat/test-sce_to_anndata.R
+++ b/tests/testthat/test-sce_to_anndata.R
@@ -12,6 +12,15 @@ colData(sce) <- DataFrame("test_column" = sample(0:10, 100, rep = TRUE),
                           row.names = barcodes)
 rowData(sce) <- DataFrame("test_row" = sample(0:10, 200, rep = TRUE))
 
+# add some metadata
+metadata(sce) <- list(
+  library_id = "library1",
+  sample_metadata = data.frame(
+    library_id = "library1",
+    sample_id = "sample1"
+  )
+)
+
 # define anndata output
 tempdir <- tempdir()
 anndata_file <- file.path(tempdir, "anndata.h5")
@@ -29,6 +38,13 @@ test_that("Conversion of SCE to AnnData works as expected", {
   expect_equal(dim(sce), dim(converted_sce))
   expect_equal(colnames(colData(sce)), colnames(colData(converted_sce)))
   expect_equal(colnames(rowData(sce)), colnames(rowData(converted_sce)))
+
+
+  # expect that sample metadata has been removed from converted SCE and only library id remains
+  expect_setequal(
+    "library_id",
+    names(metadata(converted_sce))
+  )
 
   # test that H5 file is created with new assay name
   # add logcounts


### PR DESCRIPTION
Closes #231 

Here I make some modifications to the `metadata` of an SCE object before conversion. Specifically, I'm removing any objects or `data.frame`s. We've seen issues with complex objects, but I've also seen issues with `data.frame`s, depending on the contents. After removing items from metadata, a warning displays the removed items. For our processed objects, that's `sample_metadata`, `miQC_model`, `singler_results`, and `cellassign_predictions`. 
I also updated the tests slightly to ensure the proper items are removed. 
