### PR TITLE
Don't convert any single gene single-cell objects

### DIFF
--- a/R/sce_to_anndata.R
+++ b/R/sce_to_anndata.R
@@ -33,6 +33,10 @@ sce_to_anndata <- function(sce, anndata_file, x_assay_name = "counts") {
     stop("Input SingleCellExperiment must contain at least 2 cells.")
   }
 
+  if(nrow(sce) < 2){
+    stop("Input SingleCellExperiment must contain at least 2 genes or features.")
+  }
+
   # check that filename is in the proper format for writing h5
   if (!(stringr::str_ends(anndata_file, ".hdf5|.h5"))) {
     stop("`anndata_file` must end in either '.hdf5' or '.h5'")


### PR DESCRIPTION
Here, I'm adding a check to the function for converting SCE to AnnData to make sure the SCE object has > 1 gene or feature. 
This was originally mentioned in https://github.com/AlexsLemonade/scpca-nf/pull/540#issuecomment-1795572243. 