### PR TITLE
Use AddMetaData

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -62,7 +62,7 @@ Suggests:
     scran,
     scpcaData,
     sessioninfo,
-    Seurat (< 5.0.0),
+    Seurat,
     testthat (>= 3.1.9),
     zellkonverter
 Remotes:

--- a/R/sce_to_seurat.R
+++ b/R/sce_to_seurat.R
@@ -63,7 +63,7 @@ sce_to_seurat <- function(sce,
   )
 
   # add rowdata and metadata separately adding it while creating leaves the slots empty without warning
-  seurat_obj[[assay_name]]@var.features <- rowdata
+  seurat_obj[[assay_name]] <- Seurat::AddMetaData(seurat_obj[[assay_name]], rowdata)
   seurat_obj@misc <- metadata(sce)
 
   # grab names of altExp, if any
@@ -78,7 +78,7 @@ sce_to_seurat <- function(sce,
     # round counts and calculate total counts
     alt_counts <- round(counts(altExp(sce, name)))
 
-    # subset altExp counts and seurat object to shared cells
+    # subset altExp counts and Seurat object to shared cells
     cells_to_keep <- intersect(seurat_obj_cells, colnames(alt_counts))
     alt_counts <- alt_counts[, cells_to_keep]
 
@@ -88,7 +88,7 @@ sce_to_seurat <- function(sce,
     # add new assay along with associated row data, if any
     seurat_obj[[name]] <- Seurat::CreateAssayObject(counts = alt_counts)
     rowdata <- as.data.frame(rowData(altExp(sce, name)))
-    seurat_obj[[name]]@var.features <- rowdata
+    seurat_obj[[name]] <- Seurat::AddMetaData(seurat_obj[[name]], rowdata)
 
     # check that altExp data is present as a new assay, since Seurat sometimes fails without warning
     if (is.null(seurat_obj[[name]])) {

--- a/tests/testthat/test-sce_to_seurat.R
+++ b/tests/testthat/test-sce_to_seurat.R
@@ -3,14 +3,14 @@ sce <- sim_sce(n_cells = 100, n_genes = 200, n_empty = 0)
 colData(sce) <- data.frame(
   "test_column" = sample(0:10, 100, rep = TRUE),
   "barcodes" = colnames(sce)
-) %>%
-  tibble::column_to_rownames("barcodes") %>%
+) |>
+  tibble::column_to_rownames("barcodes") |>
   DataFrame()
 rowData(sce) <- data.frame(
   "test_row" = sample(0:10, 200, rep = TRUE),
   "gene_id" = rownames(sce)
-) %>%
-  tibble::column_to_rownames("gene_id") %>%
+) |>
+  tibble::column_to_rownames("gene_id") |>
   DataFrame()
 metadata(sce)$test <- "test"
 alt_sce <- sim_sce(n_cells = 100, n_genes = 10, n_empty = 0)
@@ -22,8 +22,8 @@ sce <- merge_altexp(sce, alt_sce, alt_name)
 rowData(altExp(sce, alt_name)) <- data.frame(
   "alt_test_row" = sample(0:5, 10, rep = TRUE),
   "alt_id" = rownames(altExp(sce, alt_name))
-) %>%
-  tibble::column_to_rownames("alt_id") %>%
+) |>
+  tibble::column_to_rownames("alt_id") |>
   DataFrame()
 
 logcounts(sce) <- counts(sce) # dummy logcounts to test the assay_name argument
@@ -42,13 +42,13 @@ test_that("Converting SCE to Seurat objects works as expected", {
 
   # can't directly check that coldata is equal because of added columns in seurat object
   expect_true(all(colnames(coldata_sce) %in% colnames(seurat_object@meta.data)))
-  expect_equal(rowdata_sce, seurat_object[["RNA"]]@var.features) # since default "counts" is used, RNA name is expected here
+  expect_equal(rowdata_sce, seurat_object[["RNA"]][[]]) # since default "counts" is used, RNA name is expected here
   expect_equal(metadata(sce), seurat_object@misc)
 
   # check that altExp data was converted and rowData
   expect_s4_class(seurat_object[[alt_name]], "Assay")
   alt_rowdata_sce <- as.data.frame(rowData(altExp(sce, alt_name)))
-  expect_equal(alt_rowdata_sce, seurat_object[[alt_name]]@var.features)
+  expect_equal(alt_rowdata_sce, seurat_object[[alt_name]][[]])
 })
 
 
@@ -66,11 +66,11 @@ test_that("Converting SCE to Seurat objects works as expected for a non-default 
 
   # can't directly check that coldata is equal because of added columns in seurat object
   expect_true(all(colnames(coldata_sce) %in% colnames(seurat_object@meta.data)))
-  expect_equal(rowdata_sce, seurat_object[["logcounts"]]@var.features)
+  expect_equal(rowdata_sce, seurat_object[["logcounts"]][[]])
   expect_equal(metadata(sce), seurat_object@misc)
 
   # check that altExp data was converted and rowData
   expect_s4_class(seurat_object[[alt_name]], "Assay")
   alt_rowdata_sce <- as.data.frame(rowData(altExp(sce, alt_name)))
-  expect_equal(alt_rowdata_sce, seurat_object[[alt_name]]@var.features)
+  expect_equal(alt_rowdata_sce, seurat_object[[alt_name]][[]])
 })


### PR DESCRIPTION
Closes #239 

This ended up a pretty small fix: I used the `AddMetaData` Seurat function rather than adding directly to the slot. I think we actually were adding the wrong slot anyway: we had been using `var.features`, whereas I think the correct slot was `meta.features` all along. Which can be accessed with just `object[[assay]][[]]` as I do in the tests now. 

I think I could have used `object[[assay]][[]] <- rowdata`, but this seemed safer.

I tested with both Seurat 4.4 and 5.0, and both seemed to work on my machine.