### PR TITLE
Add an option to compress HDF5 files

### DIFF
--- a/R/sce_to_anndata.R
+++ b/R/sce_to_anndata.R
@@ -5,7 +5,7 @@
 #' @param x_assay_name Name of assay in SCE object to save as X in AnnData. Default is "counts".
 #' @param compression Type of compression to use when exporting hdf5 files. Options are
 #'   "none", "gzip", or "lzf". Default is "gzip".
-#' @param ... Any arguments to be passed into zellkonverter::writeH5AD or zellkonverter::SCE2AnnData
+#' @param ... Any arguments to be passed into zellkonverter::writeH5AD
 #'
 #' @return original SingleCellExperiment object used as input (invisibly)
 #' **Note that any columns present in the `rowData` of an SCE object that contains
@@ -23,7 +23,13 @@
 #'   anndata_file = "test_anndata.h5"
 #' )
 #' }
-sce_to_anndata <- function(sce, anndata_file, x_assay_name = "counts", compression = "gzip", ...) {
+sce_to_anndata <- function(
+  sce, 
+  anndata_file, 
+  x_assay_name = "counts", 
+  compression = c("gzip", "none", "lzf"), 
+  ...
+) {
   if (!requireNamespace("zellkonverter", quietly = TRUE)) {
     stop("The zellkonverter package must be installed to convert objects to AnnData. No output file written.")
   }
@@ -50,9 +56,7 @@ sce_to_anndata <- function(sce, anndata_file, x_assay_name = "counts", compressi
     stop("`x_assay_name` is not an assay in `sce`")
   }
 
-  if(!compression %in% c("none", "gzip", "lzf")){
-    stop("`compression` must be one of `none`, `gzip`, or `lzf`.")
-  }
+  compression <- match.arg(compression)
 
   # assign SCE to new variable to avoid modifying input SCE
   sce_to_convert <- sce

--- a/man/sce_to_anndata.Rd
+++ b/man/sce_to_anndata.Rd
@@ -4,14 +4,25 @@
 \alias{sce_to_anndata}
 \title{Convert SingleCellExperiment objects to AnnData file stored as HDF5 file}
 \usage{
-sce_to_anndata(sce, anndata_file, x_assay_name = "counts")
+sce_to_anndata(
+  sce,
+  anndata_file,
+  x_assay_name = "counts",
+  compression = "gzip",
+  ...
+)
 }
 \arguments{
 \item{sce}{SingleCellExperiment object to be converted to AnnData as an HDF5 file}
 
-\item{anndata_file}{Path to output AnnData file. Must be an `.h5` or `.hdf5`}
+\item{anndata_file}{Path to output AnnData file. Must end in `.h5`, `.hdf5`, or `.h5ad`}
 
 \item{x_assay_name}{Name of assay in SCE object to save as X in AnnData. Default is "counts".}
+
+\item{compression}{Type of compression to use when exporting hdf5 files. Options are
+"none", "gzip", or "lzf". Default is "gzip".}
+
+\item{...}{Any arguments to be passed into zellkonverter::writeH5AD or zellkonverter::SCE2AnnData}
 }
 \value{
 original SingleCellExperiment object used as input (invisibly)

--- a/man/sce_to_anndata.Rd
+++ b/man/sce_to_anndata.Rd
@@ -8,7 +8,7 @@ sce_to_anndata(
   sce,
   anndata_file,
   x_assay_name = "counts",
-  compression = "gzip",
+  compression = c("gzip", "none", "lzf"),
   ...
 )
 }
@@ -22,7 +22,7 @@ sce_to_anndata(
 \item{compression}{Type of compression to use when exporting hdf5 files. Options are
 "none", "gzip", or "lzf". Default is "gzip".}
 
-\item{...}{Any arguments to be passed into zellkonverter::writeH5AD or zellkonverter::SCE2AnnData}
+\item{...}{Any arguments to be passed into zellkonverter::writeH5AD}
 }
 \value{
 original SingleCellExperiment object used as input (invisibly)

--- a/tests/testthat/test-sce_to_anndata.R
+++ b/tests/testthat/test-sce_to_anndata.R
@@ -70,6 +70,16 @@ test_that("Conversion of SCE to AnnData works as expected", {
   )
 })
 
+test_that("Conversion of SCE to AnnData works with additional arguments", {
+
+  # test that the H5 file is created with additional options
+  expect_snapshot_file({
+    sce_to_anndata(sce, anndata_file, verbose = FALSE)
+    anndata_file
+  })
+
+})
+
 test_that("Conversion of SCE to AnnData fails as expected", {
   # check that inputting an improper file name causes a failure
   anndata_bad_file <- tempfile(fileext = ".rds")
@@ -81,4 +91,8 @@ test_that("Conversion of SCE to AnnData fails as expected", {
   # conversion fails if < 2 cells
   small_sce <- sce[, 1]
   expect_error(sce_to_anndata(small_sce, anndata_file))
+
+  # check that conversion fails with wrong compression type
+  expect_error(sce_to_anndata(sce, anndata_file, compression = "not a compression"))
+
 })


### PR DESCRIPTION
Closes #244 

This PR adds new options to the `sce_to_anndata()` function to allow for compression of the exported HDF5 files. 

- I added a `compression` option and set the default to `gzip`. I like the idea of having a separate argument rather than just using `...`, partially as a reminder. I did not use the same default of `none` that the `zellkonverter::writeH5AD` function uses. Instead, I set it to `gzip` since I think we want to compress by default. I'm on the fence on whether that was a good decision. 
- I added `...` as an option to pass any additional arguments to the function. 
- I updated the tests to test that compression fails with an invalid option and a test to make sure using additional arguments works. Let me know if I should create any additional tests. 
- I also allowed for the `.h5ad` extension. 