### PR TITLE
Make sure all sample metadata columns are compatible before merging

### DIFF
--- a/R/merge_sce_list.R
+++ b/R/merge_sce_list.R
@@ -154,6 +154,11 @@ merge_sce_list <- function(
   # if object has sample metadata then combine into a single data frame
   if ("sample_metadata" %in% names(metadata_list)) {
     sample_metadata <- metadata_list$sample_metadata |>
+      purrr::map(\(df) {
+        # make sure all column types are compatible first
+        df <- df |>
+          dplyr::mutate(across(everything(), as.character))
+        }) |>
       dplyr::bind_rows() |>
       unique()
 

--- a/R/merge_sce_list.R
+++ b/R/merge_sce_list.R
@@ -156,7 +156,7 @@ merge_sce_list <- function(
     sample_metadata <- metadata_list$sample_metadata |>
       purrr::map(\(df) {
         # make sure all column types are compatible first
-        df <- df |>
+        df |>
           dplyr::mutate(across(everything(), as.character))
         }) |>
       dplyr::bind_rows() |>


### PR DESCRIPTION
I was noticing a recurring error when trying to run the merged workflow with the latest version of scpcaTools. Specifically I was getting the following error about the `age` columns: 

```
Error in (function (cond)  : 
  error in evaluating the argument 'x' in selecting a method for function 'unique': Can't combine `..1$age` <double> and `..2$age` <character>.
```

In digging into this a little more, I was working with two processed objects that had differing types of `age` columns. One had `character` and the other had `double`. This is probably because we updated how we deal with the `age` column in https://github.com/AlexsLemonade/ScPCA-admin/pull/722. To avoid any future conflicts between the types of columns, I am converting them all to characters before creating the combined sample metadata. 

I checked with what's going on in #251 and it looks like this section hasn't been touched, so it shouldn't cause any conflicts. 