### PR TITLE
remove python from renv tests

### DIFF
--- a/.github/workflows/R-CMD-check-renv.yaml
+++ b/.github/workflows/R-CMD-check-renv.yaml
@@ -19,14 +19,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-
       - name: Set up R
         uses: r-lib/actions/setup-r@v2
         with:
-          r-version: "4.3.2"
+          r-version: "renv"
           use-public-rspm: true
 
       - name: Set up Pandoc
@@ -35,6 +31,11 @@ jobs:
       - name: Install additional system dependencies
         run: |
           sudo apt-get install -y libcurl4-openssl-dev libglpk40
+
+      # remove requirements file to prevent renv from worrying about python
+      - name: Remove requirements.txt file
+        run: |
+          rm -f requirements.txt
 
       - name: Set up Renv & install packages
         uses: r-lib/actions/setup-renv@v2

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 
   <!-- badges: start -->
   [![R-CMD-check](https://github.com/AlexsLemonade/scpcaTools/workflows/R-CMD-check/badge.svg)](https://github.com/AlexsLemonade/scpcaTools/actions/workflows/R-CMD-check-current.yaml)
-  [![R-CMD-check-renv](https://github.com/AlexsLemonade/scpcaTools/workflows/R-CMD-check-renv/badge.svg)](https://github.com/AlexsLemonade/scpcaTools/actions/workflows/R-CMD-check-renv.yaml)
   <!-- badges: end -->
 
 The `scpcaTools` package contains a set of tools for working with single-cell and single-nuclei RNA-seq counts data.
@@ -16,7 +15,7 @@ Note that this option is only for reading in data from Alevin, Alevin-fry, and K
 
 ## Installation
 
-The package can be installed from github with:
+The package can be installed from GitHub with:
 
 ```r
 remotes::install_github("AlexsLemonade/scpcaTools")
@@ -68,8 +67,3 @@ Note that `renv::status()` may not report that the `requirements.txt` file is ou
 ### Docker installation
 
 Any packages in `requirements.txt` will automatically be added to the Docker image when it is built, so you should not need to do anything special beyond the above steps to add them to the docker image.
-
-
-
-
-

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,4 +1,14 @@
+Alevin
+CMD
 commenter
+Dockerfile
+Kallisto
+nf
 pre
+PRs
+RStudio
+ScPCA
+scpca
 scpcaTools
 tidyverse
+unspliced


### PR DESCRIPTION
We don't use python in our scpcaTools tests; it is only there for other uses in the dockerfile, so I think we can safely remove it before restoring with renv.

Should hopefully solve the hash mismatch problems we were seeing. And speed up testing a bit.