### PR TITLE
Add more altExp merging tests

### DIFF
--- a/tests/testthat/test-merge_sce_list.R
+++ b/tests/testthat/test-merge_sce_list.R
@@ -592,8 +592,8 @@ test_that("merging SCEs where 1 altExp is missing works as expected, with altexp
 test_that("merging SCEs with different altExps works as expected; each SCE has 1 altExp of a different name", {
   sce1 <- sce_list_with_altexp[[1]]
   sce2 <- sce_list_with_altexp[[2]]
-
-  altExpNames(sce2) <- "other"
+  other_altexp_name <- "other"
+  altExpNames(sce2) <- other_altexp_name
   rownames(altExp(sce2)) <- c("ADT-A", "ADT-B", "ADT-C", "ADT-D", "ADT-E")
 
   sce_list <- list(
@@ -614,7 +614,7 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
   # Correct names
   expect_equal(
     altExpNames(merged_sce),
-    c(altexp_name, "other")
+    c(altexp_name, other_altexp_name)
   )
 
   # Check the "adt" (`altexp_name`) altexp
@@ -656,8 +656,105 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
 
 
 
+test_that("merging SCEs with different altExps works as expected; each SCE has 2 different altExps", {
+  other_altexp_name <- "other"
+  other_n_features <- 3
+  sce1 <- sce_list_with_altexp[[1]]
+  sce2 <- sce_list_with_altexp[[2]]
 
-# TODO: ANOTHER TEST WHERE THERE ARE MUTLIPLE ALTEXPS IN THE SAME
+  sce_list <- list(
+    "sce1" = sce_list_with_altexp[[1]],
+    "sce2" = sce_list_with_altexp[[2]]
+  ) |>
+    # add "other" altExp to each sce
+    purrr::imap(
+      add_sce_altexp,
+      other_altexp_name,
+      other_n_features,
+      ncol(sce1)
+    )
+
+  # Merge
+  merged_sce <- merge_sce_list(
+    sce_list,
+    batch_column = batch_column,
+    # "total" should get removed
+    retain_coldata_cols = retain_coldata_cols,
+    # this row name should not be modified:
+    preserve_rowdata_cols = c("gene_names")
+  )
+
+  # Correct names
+  expect_equal(
+    altExpNames(merged_sce),
+    c(altexp_name, other_altexp_name)
+  )
+
+  # Check the "adt" (`altexp_name`) altexp
+  adt_merged <- altExp(merged_sce, altexp_name)
+  expect_equal(
+    dim(adt_merged),
+    c(num_altexp_features, ncol(merged_sce))
+  )
+  expect_equal(
+    rownames(adt_merged),
+    rownames(altExp(sce1, altexp_name))
+  )
+  expect_equal(
+    colnames(adt_merged),
+    colnames(merged_sce)
+  )
+
+  # next two tests check matrix values
+  expect_equal(
+    counts(adt_merged)[, merged_sce[[batch_column]] == "sce1"] |>
+      as.matrix() |>
+      unname(),
+    counts(altExp(sce_list[[1]], altexp_name)) |>
+      as.matrix() |>
+      unname()
+  )
+  expect_equal(
+    counts(adt_merged)[, merged_sce[[batch_column]] == "sce2"] |>
+      as.matrix() |>
+      unname(),
+    counts(altExp(sce_list[[2]], altexp_name)) |>
+      as.matrix() |>
+      unname()
+  )
+
+  # Check the "other"  altexp
+  other_merged <- altExp(merged_sce, other_altexp_name)
+  expect_equal(
+    dim(other_merged),
+    c(other_n_features, ncol(merged_sce))
+  )
+  expect_equal(
+    rownames(other_merged),
+    rownames(altExp(sce_list[[1]], other_altexp_name))
+  )
+  expect_equal(
+    colnames(other_merged),
+    colnames(merged_sce)
+  )
+  # next two tests check matrix values
+  expect_equal(
+    counts(other_merged)[, merged_sce[[batch_column]] == "sce1"] |>
+      as.matrix() |>
+      unname(),
+    counts(altExp(sce_list[[1]], other_altexp_name)) |>
+      as.matrix() |>
+      unname()
+  )
+  expect_equal(
+    counts(other_merged)[, merged_sce[[batch_column]] == "sce2"] |>
+      as.matrix() |>
+      unname(),
+    counts(altExp(sce_list[[2]], other_altexp_name)) |>
+      as.matrix() |>
+      unname()
+  )
+})
 
 
 

--- a/tests/testthat/test-merge_sce_list.R
+++ b/tests/testthat/test-merge_sce_list.R
@@ -658,9 +658,6 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
 
 
 
-
-
-# TODO: ANOTHER TEST FOR CITE AND HASH TOGETHER - ONLY CITE SHOULD MAKE IT IN
 # TODO: ANOTHER TEST WHERE THERE ARE MUTLIPLE ALTEXPS IN THE SAME
 
 

--- a/tests/testthat/test-merge_sce_list.R
+++ b/tests/testthat/test-merge_sce_list.R
@@ -595,8 +595,6 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
 
   altExpNames(sce2) <- "other"
   rownames(altExp(sce2)) <- c("ADT-A", "ADT-B", "ADT-C", "ADT-D", "ADT-E")
-  colnames(colData(altExp(sce2))) <- c("col1")
-  colnames(rowData(altExp(sce2))) <- c("rcol1", "rcol2", "rcol3")
 
   sce_list <- list(
     "sce1" = sce1,
@@ -655,6 +653,7 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
     all(is.na(counts(other_merged)[, merged_sce[[batch_column]] == "sce1"]))
   )
 })
+
 
 
 

--- a/tests/testthat/test-merge_sce_list.R
+++ b/tests/testthat/test-merge_sce_list.R
@@ -714,11 +714,9 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 2
   )
   expect_equal(
     counts(adt_merged)[, merged_sce[[batch_column]] == "sce2"] |>
-      as.matrix() |>
-      unname(),
+      as.numeric(),
     counts(altExp(sce_list[[2]], altexp_name)) |>
-      as.matrix() |>
-      unname()
+      as.numeric()
   )
 
   # Check the "other"  altexp
@@ -738,19 +736,15 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 2
   # next two tests check matrix values
   expect_equal(
     counts(other_merged)[, merged_sce[[batch_column]] == "sce1"] |>
-      as.matrix() |>
-      unname(),
+      as.numeric(),
     counts(altExp(sce_list[[1]], other_altexp_name)) |>
-      as.matrix() |>
-      unname()
+      as.numeric()
   )
   expect_equal(
     counts(other_merged)[, merged_sce[[batch_column]] == "sce2"] |>
-      as.matrix() |>
-      unname(),
+      as.numeric(),
     counts(altExp(sce_list[[2]], other_altexp_name)) |>
-      as.matrix() |>
-      unname()
+      as.numeric()
   )
 })
 

--- a/tests/testthat/test-merge_sce_list.R
+++ b/tests/testthat/test-merge_sce_list.R
@@ -612,7 +612,7 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
   )
 
   # Correct names
-  expect_equal(
+  expect_setequal(
     altExpNames(merged_sce),
     c(altexp_name, other_altexp_name)
   )
@@ -625,7 +625,7 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
   )
   expect_equal(
     rownames(adt_merged),
-    rownames(altExp(sce1))
+    rownames(altExp(sce1, altexp_name))
   )
   expect_equal(
     colnames(adt_merged),
@@ -636,7 +636,7 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
   )
 
   # Check the "other"  altexp
-  other_merged <- altExp(merged_sce, "other")
+  other_merged <- altExp(merged_sce, other_altexp_name)
   expect_equal(
     dim(other_merged),
     c(num_altexp_features, ncol(merged_sce))
@@ -685,7 +685,7 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 2
   )
 
   # Correct names
-  expect_equal(
+  expect_setequal(
     altExpNames(merged_sce),
     c(altexp_name, other_altexp_name)
   )
@@ -708,11 +708,9 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 2
   # next two tests check matrix values
   expect_equal(
     counts(adt_merged)[, merged_sce[[batch_column]] == "sce1"] |>
-      as.matrix() |>
-      unname(),
+      as.numeric(),
     counts(altExp(sce_list[[1]], altexp_name)) |>
-      as.matrix() |>
-      unname()
+      as.numeric()
   )
   expect_equal(
     counts(adt_merged)[, merged_sce[[batch_column]] == "sce2"] |>


### PR DESCRIPTION
Closes #254 

This PR adds two more test suites to the SCE merging for altexps (not to be confused with `merge_altexp` 🥴) :

1) Test merging two SCEs, where the first one has an altExp named `adt` and the second has an altExp named `other`
2) Test merging two SCES, where each has two altExps named `adt` and `other`.

All is locally passing! Any other cases we'd like to see here? 

I assume I have some test redundancy here too since there are many tests in this file, but they are all quick at least. If there are glaringly obvious spots I can trim down, let me know!
