### PR TITLE
Update column handling in merge_sce_list

### DIFF
--- a/R/merge_sce_list.R
+++ b/R/merge_sce_list.R
@@ -155,19 +155,6 @@ merge_sce_list <- function(
     # (altexp_name = list(  features = c(features), assays = c(assays) ))
     altexp_attributes <- get_altexp_attributes(sce_list)
 
-    # Define more main SCE colData columns to keep, based on altExp names
-    coldata_suffixes <- c("sum", "detected", "percent")
-    altexp_columns <- glue::glue("altexps_{names(altexp_attributes)}") |>
-      purrr::map(
-        \(prefix) {
-          glue::glue("{prefix}_{coldata_suffixes}")
-        }
-      ) |>
-      unlist()
-
-    # Update retain_coldata_cols
-    retain_coldata_cols <- c(retain_coldata_cols, altexp_columns)
-
     # Check each altExp metadata, for SCEs with the altExp
     names(altexp_attributes) |>
       purrr::walk(

--- a/R/merge_sce_list.R
+++ b/R/merge_sce_list.R
@@ -206,8 +206,8 @@ merge_sce_list <- function(
       batch_column = batch_column,
       cell_id_column = cell_id_column,
       shared_features = shared_features,
-      retain_coldata_cols = retain_coldata_cols,
-      preserve_rowdata_cols = preserve_rowdata_cols
+      retain_coldata_cols = unique(retain_coldata_cols),
+      preserve_rowdata_cols = unique(preserve_rowdata_cols)
     )
 
 
@@ -228,8 +228,8 @@ merge_sce_list <- function(
           expected_features = expected_features,
           batch_column = batch_column,
           cell_id_column = cell_id_column,
-          retain_coldata_cols = altexp_coldata_cols,
-          preserve_rowdata_cols = altexp_rowdata_cols
+          retain_coldata_cols = unique(altexp_coldata_cols),
+          preserve_rowdata_cols = unique(altexp_rowdata_cols)
         )
     }
   }

--- a/tests/testthat/test-merge_sce_list.R
+++ b/tests/testthat/test-merge_sce_list.R
@@ -513,7 +513,12 @@ test_that("merging SCEs with 1 altexp and same features works as expected, with 
     sce_list_with_altexp,
     batch_column = batch_column,
     # "total" should get removed
-    retain_coldata_cols = retain_coldata_cols,
+    retain_coldata_cols = c(
+      retain_coldata_cols,
+      "altexps_adt_sum",
+      "altexps_adt_detected",
+      "altexps_adt_percent"
+    ),
     # this row name should not be modified:
     preserve_rowdata_cols = c("gene_names")
   )
@@ -665,9 +670,6 @@ test_that("merging SCEs where 1 altExp is missing works as expected, with altexp
   expected_coldata <- c(
     "sum",
     "detected",
-    "altexps_adt_sum",
-    "altexps_adt_detected",
-    "altexps_adt_percent",
     batch_column,
     cell_id_column
   )


### PR DESCRIPTION
Closes #263 
As discussed in https://github.com/AlexsLemonade/scpca-nf/pull/666#discussion_r1465730488, I've removed the altExp columns from this function. I also ensure that any vector of retained/preserved columns is unique when it goes into its relevant crux function.

I've updated over in my draft PR in `scpca-nf` as well: https://github.com/AlexsLemonade/scpca-nf/pull/666/commits/061100671bbb2dc3f4aae2018dde392991747fc3
