### PR TITLE
Add batchelor to the slim image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,10 @@ RUN Rscript -e "install.packages(c('renv'))"
 
 COPY docker/renv_slim.lock renv.lock
 # restore renv and remove cache files
-RUN Rscript -e 'renv::restore()' && \
-  rm -rf ~/.cache/R/renv && \
-  rm -rf /tmp/downloaded_packages && \
-  rm -rf /tmp/Rtmp*
+RUN Rscript -e 'renv::restore()'\
+  && rm -rf ~/.cache/R/renv \
+  && rm -rf /tmp/downloaded_packages \
+  && rm -rf /tmp/Rtmp*
 
 
 # Install scpcaTools package (& test loading)
@@ -32,10 +32,10 @@ FROM slim AS seurat
 LABEL org.opencontainers.image.title "scpcatools-seurat"
 
 COPY docker/renv_seurat.lock renv.lock
-RUN Rscript -e 'renv::restore()' && \
-  rm -rf ~/.cache/R/renv && \
-  rm -rf /tmp/downloaded_packages && \
-  rm -rf /tmp/Rtmp*
+RUN Rscript -e 'renv::restore()'\
+  && rm -rf ~/.cache/R/renv \
+  && rm -rf /tmp/downloaded_packages \
+  && rm -rf /tmp/Rtmp*
 
 
 ##########################
@@ -43,11 +43,17 @@ RUN Rscript -e 'renv::restore()' && \
 FROM slim AS reports
 LABEL org.opencontainers.image.title "scpcatools-reports"
 
+RUN apt-get -y update &&  \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install --no-install-recommends -y \
+    pandoc \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY docker/renv_reports.lock renv.lock
-RUN Rscript -e 'renv::restore()' && \
-  rm -rf ~/.cache/R/renv && \
-  rm -rf /tmp/downloaded_packages && \
-  rm -rf /tmp/Rtmp*
+RUN Rscript -e 'renv::restore()'\
+  && rm -rf ~/.cache/R/renv \
+  && rm -rf /tmp/downloaded_packages \
+  && rm -rf /tmp/Rtmp*
 
 
 ##########################
@@ -56,10 +62,10 @@ FROM slim AS anndata
 LABEL org.opencontainers.image.title "scpcatools-anndata"
 
 COPY docker/renv_zellkonverter.lock renv.lock
-RUN Rscript -e 'renv::restore()' && \
-  rm -rf ~/.cache/R/renv && \
-  rm -rf /tmp/downloaded_packages && \
-  rm -rf /tmp/Rtmp*
+RUN Rscript -e 'renv::restore()'\
+  && rm -rf ~/.cache/R/renv \
+  && rm -rf /tmp/downloaded_packages \
+  && rm -rf /tmp/Rtmp*
 
 # Complete installation of zellkonverter conda env
 ENV BASILISK_EXTERNAL_DIR /usr/local/renv/basilisk
@@ -86,11 +92,17 @@ RUN pip install --no-cache-dir -r requirements.txt
 FROM scvi AS full
 LABEL org.opencontainers.image.title "scpcatools"
 
+RUN apt-get -y update &&  \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get install --no-install-recommends -y \
+    pandoc \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY renv.lock renv.lock
-RUN Rscript -e 'renv::restore()' && \
-  rm -rf ~/.cache/R/renv && \
-  rm -rf /tmp/downloaded_packages && \
-  rm -rf /tmp/Rtmp*
+RUN Rscript -e 'renv::restore()'\
+  && rm -rf ~/.cache/R/renv \
+  && rm -rf /tmp/downloaded_packages \
+  && rm -rf /tmp/Rtmp*
 
 COPY docker/requirements.txt requirements.txt
 

--- a/docker/make-requirements.sh
+++ b/docker/make-requirements.sh
@@ -14,7 +14,7 @@ pip-compile --no-annotate --strip-extras --output-file=requirements_anndata.txt 
 pip-compile --no-annotate --strip-extras --output-file=requirements_scvi.txt requirements_scvi.in
 
 # slim lockfile
-Rscript scripts/make-lockfile.R -f renv_slim.lock
+Rscript scripts/make-lockfile.R -f renv_slim.lock -p batchelor
 
 # reports lockfile
 Rscript scripts/make-lockfile.R -f renv_reports.lock -p ComplexHeatmap,ggforce,kableExtra,rmarkdown


### PR DESCRIPTION
When running the merge workflow, I found that I did need `batchelor` installed, which I think was the only thing beyond the `slim` packages that was needed. So I am adding it here, because the ability to do clustering does seem reasonable to include in all images.