### PR TITLE
Add rounding to alevin-fry import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scpcaTools
 Type: Package
 Title: Single cell data tools for ScPCA
-Version: 0.4.0
+Version: 0.4.1
 Authors@R: c(
     person("Ally", "Hawkins",
            email = "ally.hawkins@ccdatalab.org",

--- a/R/read_alevin.R
+++ b/R/read_alevin.R
@@ -118,6 +118,9 @@ read_alevin <- function(
       fryDir = quant_dir,
       outputFormat = assay_formats
     )
+    if (round_counts) {
+      assays(sce) <- lapply(assays(sce), round)
+    }
   } else {
     # read in any non-USA formatted alevin-fry data or Alevin data
     counts <- read_tximport(quant_dir)


### PR DESCRIPTION
Apparently when we switched to using `fishpond` for more efficient importing, we forgot to ensure that the counts were still rounded. I am adding a step to round the counts here, which should fix https://github.com/AlexsLemonade/scpca-nf/issues/790 once we update and reprocess all of the samples.