### PR TITLE
Output merged SCE as dgCMatrix

### DIFF
--- a/R/merge_sce_list.R
+++ b/R/merge_sce_list.R
@@ -240,7 +240,7 @@ merge_sce_list <- function(
   }
 
   # Create the merged SCE from the processed list
-  merged_sce <- do.call(combineCols, unname(sce_list))
+  merged_sce <- do.call(combineCols, c(unname(sce_list), delayed = FALSE))
 
   # Update metadata in merged objects, using the unmerged sce_list
   metadata(merged_sce) <- sce_list |>

--- a/R/merge_sce_list.R
+++ b/R/merge_sce_list.R
@@ -238,6 +238,15 @@ merge_sce_list <- function(
         )
     }
 
+  }
+
+  # Merge SCEs ------------------------------------------------------
+
+  if(!include_altexp){
+    # Create the merged SCE from the processed list
+    # only use delayed = FALSE if no altExps
+    merged_sce <- do.call(combineCols, c(unname(sce_list), delayed = FALSE))
+  } else {
     # if using alt exp, need to merge and then convert to dgCMatrix
     merged_sce <- do.call(combineCols, unname(sce_list))
 
@@ -256,10 +265,6 @@ merge_sce_list <- function(
       altExp(merged_sce, altexp_name) <- alt_merged_sce
     }
 
-  } else {
-    # Create the merged SCE from the processed list
-    # only use delayed = FALSE if no altExps
-    merged_sce <- do.call(combineCols, c(unname(sce_list), delayed = FALSE))
   }
 
   # Update metadata in merged objects, using the unmerged sce_list

--- a/scpcaTools.Rproj
+++ b/scpcaTools.Rproj
@@ -1,4 +1,5 @@
 Version: 1.0
+ProjectId: eea1f055-3bfc-40f1-809c-f8071c1b147f
 
 RestoreWorkspace: Default
 SaveWorkspace: Default

--- a/tests/testthat/test-merge_sce_list.R
+++ b/tests/testthat/test-merge_sce_list.R
@@ -183,10 +183,8 @@ test_that("merging SCEs with matching genes works as expected, no altexps", {
   )
 
   # check format of output
-  expect_true(
-    is(counts(merged_sce), "dgCMatrix"),
-    is(logcounts(merged_sce), "dgCMatrix")
-  )
+  expect_s4_class(counts(merged_sce), "CsparseMatrix")
+  expect_s4_class(logcounts(merged_sce), "CsparseMatrix")
 
   # metadata names check
   expect_contains(

--- a/tests/testthat/test-merge_sce_list.R
+++ b/tests/testthat/test-merge_sce_list.R
@@ -447,6 +447,13 @@ test_that("merging SCEs with altExps works as expected when include_altexps = FA
 
   # there should not be any altExps
   expect_length(altExpNames(merged_sce), 0)
+
+  # check format of output
+  expect_true(
+    is(counts(merged_sce), "dgCMatrix"),
+    is(logcounts(merged_sce), "dgCMatrix")
+  )
+
 })
 
 
@@ -695,7 +702,7 @@ test_that("merging SCEs where 1 altExp is missing works as expected, with altexp
   counts_mat <- counts(merged_altexp)
   sce4_counts <- counts_mat[, merged_sce[[batch_column]] == "sce4"]
   expect_true(
-    all(is.na(sce4_counts))
+    all(sce4_counts == 0)
   )
   numeric_counts <- counts_mat[, merged_sce[[batch_column]] != "sce4"]
   expect_true(
@@ -747,7 +754,7 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
     colnames(merged_sce)
   )
   expect_true(
-    all(is.na(counts(adt_merged)[, merged_sce[[batch_column]] == "sce2"]))
+    all(counts(adt_merged)[, merged_sce[[batch_column]] == "sce2"]== 0 )
   )
 
   # Check the "other"  altexp
@@ -765,7 +772,7 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
     colnames(merged_sce)
   )
   expect_true(
-    all(is.na(counts(other_merged)[, merged_sce[[batch_column]] == "sce1"]))
+    all(counts(other_merged)[, merged_sce[[batch_column]] == "sce1"] == 0)
   )
 })
 

--- a/tests/testthat/test-merge_sce_list.R
+++ b/tests/testthat/test-merge_sce_list.R
@@ -748,7 +748,7 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
     colnames(merged_sce)
   )
   expect_equal(
-    sum(counts(adt_merged)[, merged_sce[[batch_column]] == "sce2"]), 0
+    sum(abs(counts(adt_merged)[, merged_sce[[batch_column]] == "sce2"])), 0
   )
 
   # Check the "other"  altexp
@@ -766,7 +766,7 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
     colnames(merged_sce)
   )
   expect_equal(
-    sum(counts(adt_merged)[, merged_sce[[batch_column]] == "sce1"]), 0
+    sum(abs(counts(other_merged)[, merged_sce[[batch_column]] == "sce1"])), 0
   )
 })
 

--- a/tests/testthat/test-merge_sce_list.R
+++ b/tests/testthat/test-merge_sce_list.R
@@ -182,6 +182,12 @@ test_that("merging SCEs with matching genes works as expected, no altexps", {
     c("counts", "logcounts")
   )
 
+  # check format of output
+  expect_true(
+    is(counts(merged_sce), "dgCMatrix"),
+    is(logcounts(merged_sce), "dgCMatrix")
+  )
+
   # metadata names check
   expect_contains(
     names(metadata(merged_sce)),
@@ -280,7 +286,7 @@ test_that("merging SCEs with different genes among input SCEs works as expected,
 
 
 
-test_that("merging SCEs with no matching genes fails as expected, no altexps, no altexps", {
+test_that("merging SCEs with no matching genes fails as expected, no altexps", {
   # ensure different gene names entirely
   rownames(sce_list[[1]]) <- rownames(sce_list[[2]])
   rownames(sce_list[[1]]) <- paste0(rownames(sce_list[[1]]), "-new")
@@ -481,6 +487,13 @@ test_that("merging SCEs with altExps has correct altExp colData names when retai
     expected_cols,
     observed_cols
   )
+
+  # check format of output
+  expect_true(
+    is(counts(altExp(merged_sce)), "dgCMatrix"),
+    is(logcounts(altExp(merged_sce)), "dgCMatrix")
+  )
+
 })
 
 

--- a/tests/testthat/test-merge_sce_list.R
+++ b/tests/testthat/test-merge_sce_list.R
@@ -447,10 +447,8 @@ test_that("merging SCEs with altExps works as expected when include_altexps = FA
   expect_length(altExpNames(merged_sce), 0)
 
   # check format of output
-  expect_true(
-    is(counts(merged_sce), "dgCMatrix"),
-    is(logcounts(merged_sce), "dgCMatrix")
-  )
+  expect_s4_class(counts(merged_sce), "CsparseMatrix")
+  expect_s4_class(logcounts(merged_sce), "CsparseMatrix")
 
 })
 
@@ -494,10 +492,8 @@ test_that("merging SCEs with altExps has correct altExp colData names when retai
   )
 
   # check format of output
-  expect_true(
-    is(counts(altExp(merged_sce)), "dgCMatrix"),
-    is(logcounts(altExp(merged_sce)), "dgCMatrix")
-  )
+  expect_s4_class(counts(altExp(merged_sce)), "CsparseMatrix")
+  expect_s4_class(logcounts(altExp(merged_sce)), "CsparseMatrix")
 
 })
 
@@ -696,11 +692,11 @@ test_that("merging SCEs where 1 altExp is missing works as expected, with altexp
     expected_coldata
   )
 
-  # check that the NAs are as expected
+  # check that the 0s/NAs are as expected
   counts_mat <- counts(merged_altexp)
   sce4_counts <- counts_mat[, merged_sce[[batch_column]] == "sce4"]
-  expect_true(
-    all(sce4_counts == 0)
+  expect_equal(
+    sum(abs(sce4_counts)), 0
   )
   numeric_counts <- counts_mat[, merged_sce[[batch_column]] != "sce4"]
   expect_true(
@@ -751,8 +747,8 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
     colnames(adt_merged),
     colnames(merged_sce)
   )
-  expect_true(
-    all(counts(adt_merged)[, merged_sce[[batch_column]] == "sce2"]== 0 )
+  expect_equal(
+    sum(counts(adt_merged)[, merged_sce[[batch_column]] == "sce2"]), 0
   )
 
   # Check the "other"  altexp
@@ -769,8 +765,8 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
     colnames(adt_merged),
     colnames(merged_sce)
   )
-  expect_true(
-    all(counts(other_merged)[, merged_sce[[batch_column]] == "sce1"] == 0)
+  expect_equal(
+    sum(counts(adt_merged)[, merged_sce[[batch_column]] == "sce1"]), 0
   )
 })
 


### PR DESCRIPTION
Closes #289 

Here I made a small change to the `merge_sce_list` function to make sure the output matrix is not a`delayedMatrix`. To do this I just added the `delayed=FALSE` option to the `combineCols` call. I tested the run time of this vs. the original function with a small set of SCEs and it took 2 seconds instead of 1 second so there is going to be some increased time. I also tested directly converting the counts assay  to a `CsparseMatrix` after creating the object and that took 3 seconds, so I think this is our best option. 