### PR TITLE
Leave altExps (potentially) dense to preserve NA values

### DIFF
--- a/R/merge_sce_list.R
+++ b/R/merge_sce_list.R
@@ -260,7 +260,7 @@ merge_sce_list <- function(
     for(altexp_name in names(altexp_attributes)){
       alt_merged_sce <- altExp(merged_sce, altexp_name)
       for(name in assayNames(alt_merged_sce)){
-        assay(alt_merged_sce, name) <- as(assay(alt_merged_sce, name), "CsparseMatrix")
+        assay(alt_merged_sce, name) <- as(assay(alt_merged_sce, name), "Matrix")
       }
       altExp(merged_sce, altexp_name) <- alt_merged_sce
     }

--- a/R/merge_sce_list.R
+++ b/R/merge_sce_list.R
@@ -256,7 +256,7 @@ merge_sce_list <- function(
       assay(merged_sce, name) <- as(assay(merged_sce, name), "CsparseMatrix")
     }
 
-    # now for the alt exps, but leave them dense
+    # now for the alt exps: make sure they are Matrix class (not Delayed)
     for(altexp_name in names(altexp_attributes)){
       alt_merged_sce <- altExp(merged_sce, altexp_name)
       for(name in assayNames(alt_merged_sce)){

--- a/R/merge_sce_list.R
+++ b/R/merge_sce_list.R
@@ -247,7 +247,7 @@ merge_sce_list <- function(
     # only use delayed = FALSE if no altExps
     merged_sce <- do.call(combineCols, c(unname(sce_list), delayed = FALSE))
   } else {
-    # if using alt exp, need to merge and then convert to dgCMatrix
+    # if using alt exp, need to merge and then convert to CsparseMatrix
     merged_sce <- do.call(combineCols, unname(sce_list))
 
     # first update the assays in the main exp
@@ -256,7 +256,7 @@ merge_sce_list <- function(
       assay(merged_sce, name) <- as(assay(merged_sce, name), "CsparseMatrix")
     }
 
-    # now for the alt exps
+    # now for the alt exps, but leave them dense
     for(altexp_name in names(altexp_attributes)){
       alt_merged_sce <- altExp(merged_sce, altexp_name)
       for(name in assayNames(alt_merged_sce)){

--- a/renv.lock
+++ b/renv.lock
@@ -184,13 +184,13 @@
     },
     "BiocManager": {
       "Package": "BiocManager",
-      "Version": "1.30.23",
+      "Version": "1.30.25",
       "Source": "Repository",
-      "Repository": "RSPM",
+      "Repository": "CRAN",
       "Requirements": [
         "utils"
       ],
-      "Hash": "47e968dfe563c1b22c2e20a067ec21d5"
+      "Hash": "3aec5928ca10897d7a0a1205aae64627"
     },
     "BiocNeighbors": {
       "Package": "BiocNeighbors",

--- a/tests/testthat/test-merge_sce_list.R
+++ b/tests/testthat/test-merge_sce_list.R
@@ -492,8 +492,8 @@ test_that("merging SCEs with altExps has correct altExp colData names when retai
   )
 
   # check format of output
-  expect_s4_class(counts(altExp(merged_sce)), "CsparseMatrix")
-  expect_s4_class(logcounts(altExp(merged_sce)), "CsparseMatrix")
+  expect_s4_class(counts(altExp(merged_sce)), "Matrix")
+  expect_s4_class(logcounts(altExp(merged_sce)), "Matrix")
 
 })
 
@@ -693,14 +693,14 @@ test_that("merging SCEs where 1 altExp is missing works as expected, with altexp
   )
 
   # check that the 0s/NAs are as expected
-  counts_mat <- counts(merged_altexp)
-  sce4_counts <- counts_mat[, merged_sce[[batch_column]] == "sce4"]
-  expect_equal(
-    sum(abs(sce4_counts)), 0
-  )
-  numeric_counts <- counts_mat[, merged_sce[[batch_column]] != "sce4"]
+  adt_counts_mat <- counts(merged_altexp)
+  sce4_adt_counts <- adt_counts_mat[, merged_sce[[batch_column]] == "sce4"]
   expect_true(
-    all(is.finite(numeric_counts))
+    all(is.na(sce4_adt_counts))
+  )
+  numeric_counts <- adt_counts_mat[, merged_sce[[batch_column]] != "sce4"]
+  expect_true(
+    all(numeric_counts >= 0)
   )
 })
 
@@ -747,8 +747,9 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
     colnames(adt_merged),
     colnames(merged_sce)
   )
-  expect_equal(
-    sum(abs(counts(adt_merged)[, merged_sce[[batch_column]] == "sce2"])), 0
+  sce2_adt_counts <- counts(adt_merged)[, merged_sce[[batch_column]] == "sce2"]
+  expect_true(
+    all(is.na(sce2_adt_counts))
   )
 
   # Check the "other"  altexp
@@ -765,8 +766,9 @@ test_that("merging SCEs with different altExps works as expected; each SCE has 1
     colnames(adt_merged),
     colnames(merged_sce)
   )
-  expect_equal(
-    sum(abs(counts(other_merged)[, merged_sce[[batch_column]] == "sce1"])), 0
+  sce1_adt_counts <- counts(other_merged)[, merged_sce[[batch_column]] == "sce1"]
+  expect_true(
+    all(is.na(sce1_adt_counts))
   )
 })
 


### PR DESCRIPTION
As an alternate solution to #293, here I am changing the conversion of the altExps to be to leave them as dense matrices, so as to preserve the `NA` values for missing columns.  I also updated the tests to match.

I tested this both with the current renv and after updating all packages to the latest versions, so I expect this to pass both the pre- and post-merge testing.

There is also a very small renv update, because renv refused to restore on a new machine without updating `BiocManager`, so I added that small update.

At some point in the future we might want change to sparse matrices for altExps as well, and it seems from #293 that this could preserve the NA values with newer versions of the `Matrix` package: we may want to investigate when that change happened and update requirements (and the `renv`) to specify that version. But for now, I think leaving these matrices dense should be fine; they are small (compared to the RNA expression matrices), and tend to be denser anyway.