### PR TITLE
Update read cellranger to read in H5 file

### DIFF
--- a/R/import_quant_data.R
+++ b/R/import_quant_data.R
@@ -4,6 +4,9 @@
 #'   and returns a SingleCellExperiment.
 #'
 #' @param quant_dir Path to directory where output files are located.
+#'   Used when tool is alevin, alevin-fry, or kallisto.
+#' @param cellranger_h5_file Optional path to H5 file output by Cell Ranger.
+#'   Used when tool is cellranger.
 #' @param tool Type of tool used to create files (alevin, alevin-fry, cellranger, or kallisto).
 #' @param include_unspliced Whether or not to include the unspliced reads in the counts matrix.
 #'   If TRUE, the main "counts" assay will contain unspliced reads and spliced reads and an additional "spliced"
@@ -25,7 +28,7 @@
 #' @examples
 #' \dontrun{
 #' # read in single cell RNA seq data processed using cellranger
-#' import_quant_data(quant_dir,
+#' import_quant_data(cellranger_h5_file,
 #'   tool = "cellranger"
 #' )
 #'
@@ -56,6 +59,7 @@
 #' }
 #'
 import_quant_data <- function(quant_dir,
+                              cellranger_h5_file = "",
                               tool = c("cellranger", "alevin", "alevin-fry", "kallisto"),
                               include_unspliced = TRUE,
                               usa_mode = FALSE,
@@ -68,6 +72,7 @@ import_quant_data <- function(quant_dir,
   stopifnot(
     "Tool must be one of cellranger, alevin, alevin-fry, or kallisto." =
       tool %in% c("cellranger", "alevin", "alevin-fry", "kallisto"),
+    "h5_file must be provided when using cellranger as tool" = tool == "cellranger" & file.exists(cellranger_h5_file),
     "include_unspliced must be set as TRUE or FALSE" = is.logical(include_unspliced),
     "usa_mode must be set as TRUE or FALSE" = is.logical(usa_mode),
     "filter must be set as TRUE or FALSE" = is.logical(filter),
@@ -88,7 +93,7 @@ import_quant_data <- function(quant_dir,
   } else if (tool == "kallisto") {
     sce <- read_kallisto(quant_dir, include_unspliced)
   } else if (tool == "cellranger") {
-    sce <- read_cellranger(quant_dir)
+    sce <- read_cellranger(cellranger_h5_file)
   }
 
   if (filter) {

--- a/R/read_cellranger.R
+++ b/R/read_cellranger.R
@@ -1,6 +1,6 @@
 #' Read in counts data processed with Cell Ranger
 #'
-#' @param quant_dir Path to directory where output files are located.
+#' @param cellranger_h5_file Path to H5AD file output from Cell Ranger.
 #'
 #' @return SingleCellExperiment of gene x cell counts matrix
 #' @export
@@ -8,25 +8,26 @@
 #' @examples
 #' \dontrun{
 #'
-#' # Import data from cellranger output directory quant_dir
-#' read_cellranger(quant_dir)
+#' # Import data from cellranger output file
+#' read_cellranger(cellranger_h5_file)
 #' }
 #'
-read_cellranger <- function(quant_dir) {
-  cellranger_file <- file.path(quant_dir, "outs", "filtered_feature_bc_matrix.h5")
-  if (!file.exists(cellranger_file)) {
-    stop("Missing filtered_feature_bc_matrix.h5 file from cellranger output")
+read_cellranger <- function(cellranger_h5_file) {
+
+  if (!file.exists(cellranger_h5_file)) {
+    stop(glue::glue("{cellranger_h5_file} does not exist"))
   }
 
-  sce <- DropletUtils::read10xCounts(cellranger_file,
-    sample.names = basename(quant_dir),
+  sce <- DropletUtils::read10xCounts(
+    cellranger_h5_file,
     col.names = TRUE
   )
 
   # for consistency with other quantifiers:
   # change the column names just the barcode value, which is the first part of the barcode name
-  # drop colData
+  # drop colData and metadata
   colnames(sce) <- str_extract(colnames(sce), "^([ACGT]+)")
   SummarizedExperiment::colData(sce) <- NULL
+  SummarizedExperiment::metadata(sce) <- list()
   return(sce)
 }

--- a/man/import_quant_data.Rd
+++ b/man/import_quant_data.Rd
@@ -6,6 +6,7 @@
 \usage{
 import_quant_data(
   quant_dir,
+  cellranger_h5_file = "",
   tool = c("cellranger", "alevin", "alevin-fry", "kallisto"),
   include_unspliced = TRUE,
   usa_mode = FALSE,
@@ -16,7 +17,11 @@ import_quant_data(
 )
 }
 \arguments{
-\item{quant_dir}{Path to directory where output files are located.}
+\item{quant_dir}{Path to directory where output files are located.
+Used when tool is alevin, alevin-fry, or kallisto.}
+
+\item{cellranger_h5_file}{Optional path to H5 file output by Cell Ranger.
+Used when tool is cellranger.}
 
 \item{tool}{Type of tool used to create files (alevin, alevin-fry, cellranger, or kallisto).}
 
@@ -49,7 +54,7 @@ Imports the gene x cell matrix output from either Alevin, Alevin-fry, Cell Range
 \examples{
 \dontrun{
 # read in single cell RNA seq data processed using cellranger
-import_quant_data(quant_dir,
+import_quant_data(cellranger_h5_file,
   tool = "cellranger"
 )
 

--- a/man/read_cellranger.Rd
+++ b/man/read_cellranger.Rd
@@ -4,10 +4,10 @@
 \alias{read_cellranger}
 \title{Read in counts data processed with Cell Ranger}
 \usage{
-read_cellranger(quant_dir)
+read_cellranger(cellranger_h5_file)
 }
 \arguments{
-\item{quant_dir}{Path to directory where output files are located.}
+\item{cellranger_h5_file}{Path to H5AD file output from Cell Ranger.}
 }
 \value{
 SingleCellExperiment of gene x cell counts matrix
@@ -18,8 +18,8 @@ Read in counts data processed with Cell Ranger
 \examples{
 \dontrun{
 
-# Import data from cellranger output directory quant_dir
-read_cellranger(quant_dir)
+# Import data from cellranger output file
+read_cellranger(cellranger_h5_file)
 }
 
 }

--- a/tests/testthat/test-read_cellranger.R
+++ b/tests/testthat/test-read_cellranger.R
@@ -1,11 +1,12 @@
 dir <- system.file("extdata", package = "scpcaData")
-cellranger_dir <- file.path(dir, "Breast_Cancer_3p_LT/cellranger_cdna")
+cellranger_dir <- file.path(dir, "Breast_Cancer_3p_LT", "cellranger_cdna", "outs")
+h5_file <- file.path(cellranger_dir, "filtered_feature_bc_matrix.h5")
 
 # expected matrix size
 sce_size <- c(19970, 687)
 
 test_that("Check that cellranger import works", {
-  sce <- read_cellranger(cellranger_dir)
+  sce <- read_cellranger(h5_file)
   expect_s4_class(sce, "SingleCellExperiment")
   expect_equal(dim(sce), sce_size)
   # check that column names are barcodes


### PR DESCRIPTION
Closes #296 

This PR modifies the `read_cellranger()` function to use the path to the H5 file directly as input rather than using a `quant_dir`. While I was here, I also updated the `import_quant_data()` function to use the H5 file when the tool is `cellranger`. 

The only other thing I did here was remove the `sample.names` argument since we remove the `colData` anyways. And then I noticed that the `metadata` had `Samples` as a list item, so I made that an empty list to match the formatting of other objects. 