### PR TITLE
Potential fix for basilisk installation with ENV and TRUE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/AlexsLemonade/scpcaToo
 
 #### Build settings for Renv and Basilisk
 ENV RENV_CONFIG_CACHE_ENABLED=FALSE
-ARG BASILISK_USE_SYSTEM_DIR=1
+ENV BASILISK_USE_SYSTEM_DIR=TRUE
 
 #### R packages
 # Use renv for R packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.source="https://github.com/AlexsLemonade/scpcaToo
 
 #### Build settings for Renv and Basilisk
 ENV RENV_CONFIG_CACHE_ENABLED=FALSE
-ENV BASILISK_USE_SYSTEM_DIR=TRUE
+ENV BASILISK_USE_SYSTEM_DIR=1
 
 #### R packages
 # Use renv for R packages


### PR DESCRIPTION
After still seeing some issues with basilisk installing the environment and not being able to properly find `anndata`, I'm updating this to use `ENV` and not `ARG`. Hopefully this will set the environment variable in the container so that when it's used on a new machine it doesn't try to install the environment. 

I also think maybe `1` is incorrect and instead it should be `TRUE`. I tested this by pulling the existing image that we have in singularity and then inside the image I set the environment variable and then tried to run `basilisk`: 

Try 1: 
```
Singularity> export BASILISK_USE_SYSTEM_DIR=1
Singularity> R

R version 4.4.1 (2024-06-14) -- "Race for Your Life"
Copyright (C) 2024 The R Foundation for Statistical Computing
Platform: x86_64-pc-linux-gnu

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

  Natural language support but running in an English locale

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> proc <- basilisk::basiliskStart(env = zellkonverter::zellkonverterAnnDataEnv(), testload = 'anndata')
Registered S3 method overwritten by 'zellkonverter':
  method                                             from      
  py_to_r.pandas.core.arrays.categorical.Categorical reticulate
Error: Unable to find conda binary. Is Anaconda installed?
```

So then I tried to use `TRUE` and this is what happened, which is the correct behavior: 

```
Singularity> export BASILISK_USE_SYSTEM_DIR=TRUE
Singularity> R

R version 4.4.1 (2024-06-14) -- "Race for Your Life"
Copyright (C) 2024 The R Foundation for Statistical Computing
Platform: x86_64-pc-linux-gnu

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

  Natural language support but running in an English locale

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> proc <- basilisk::basiliskStart(env = zellkonverter::zellkonverterAnnDataEnv(), testload = 'anndata')
Registered S3 method overwritten by 'zellkonverter':
  method                                             from      
  py_to_r.pandas.core.arrays.categorical.Categorical reticulate
```

So I think setting `ENV` should work and setting the correct argument. I can build it locally and test if we prefer to do that before merging this. 

