### PR TITLE
Update basilisk installation attempt 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ LABEL org.opencontainers.image.source="https://github.com/AlexsLemonade/scpcaToo
 
 #### Build settings for Renv and Basilisk
 ENV RENV_CONFIG_CACHE_ENABLED=FALSE
-ENV BASILISK_USE_SYSTEM_DIR=1
 
 #### R packages
 # Use renv for R packages
@@ -72,6 +71,11 @@ RUN Rscript -e 'renv::restore()'\
   && rm -rf ~/.cache/R/renv \
   && rm -rf /tmp/downloaded_packages \
   && rm -rf /tmp/Rtmp*
+
+# reinstall basilisk and zellkonverter from source to force conda env installation.
+ENV BASILISK_USE_SYSTEM_DIR=1
+RUN Rscript -e 'BiocManager::install("basilisk", type = "source", force = TRUE)'
+RUN Rscript -e 'BiocManager::install("zellkonverter", type = "source", force = TRUE)'
 
 #### Python packages
 COPY docker/requirements_anndata.txt requirements.txt


### PR DESCRIPTION
Hopefully this addresses #312. 

I am using the solution from https://github.com/AlexsLemonade/scpcaTools/issues/312#issuecomment-3165818902 to not set `BASILISK_USE_SYSTEM_DIR=1` until after installing the lock file with renv. Then we set it and force re-installation of basilisk and zellkonverter. 

I did a build of this locally using the `renv_zellkonverter.lock` file and was able to build the image and then run ` basilisk::basiliskStart(env = zellkonverter::zellkonverterAnnDataEnv(), testload = 'anndata')` within the image! 

I want to test this with `scpca-nf` in Nextflow and then also test trying to use `zellkonverter` in the Singularity image to make sure the conda environment isn't rebuilding and things are working as we expect. I think the most efficient way to do that is to merge this in and update the edge image. 