### PR TITLE
Update release issue template 

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -18,9 +18,8 @@ assignees: ''
   - [ ] Create a branch in [scpca-nf](https://github.com/AlexsLemonade/scpca-nf/) for testing the latest Docker version from the `main` branch.
   - [ ] Update [containers.config](https://github.com/AlexsLemonade/scpca-nf/blob/main/config/containers.config) with the `edge` version of the scpca-tools container: ```SCPCATOOLS_CONTAINER = 'ghcr.io/alexslemonade/scpca-tools:edge'``` and push the branch to github.
   - [ ] If necessary, update the `scpca-nf` workflow to accommodate changes in the `scpcaTools` package
-  - [ ] Perform a test run of the workflow with:
-```nextflow run AlexsLemonade/scpca-nf -r "<TESTBRANCH>" -profile batch,ccdl```
-If the [default `run_ids`](https://github.com/AlexsLemonade/scpca-nf/blob/main/config/profile_ccdl.config#L12-L13 for the workflow do not cover expected changes in this tools package, you may want to specify particular test samples or projects with the `--run_id` option (use your judgement).
+  - [ ] Perform a test run of the workflow with the [`run-scpca-nf.yaml`](https://github.com/AlexsLemonade/ScPCA-admin/blob/main/.github/workflows/run-scpca-nf.yaml) workflow in the `scpca-admin` repo, specifying `testing` mode
+If the [default `run_ids`](https://github.com/AlexsLemonade/scpca-nf/blob/main/config/ccdl_profiles.config#L24-L26) for the workflow do not cover expected changes in this tools package, you may want to specify particular test samples or projects with the `--scpca_run_ids` or `--scpca_project_ids` option (use your judgement).
 
 ### Creating a release
 - [ ] On the [releases page](https://github.com/AlexsLemonade/scpcatools/releases), choose `Draft a new release`.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: scpcaTools
 Type: Package
 Title: Single cell data tools for ScPCA
-Version: 0.4.4
+Version: 0.4.5
 Authors@R: c(
     person("Ally", "Hawkins",
            email = "ally.hawkins@ccdatalab.org",


### PR DESCRIPTION
Before cutting a release here (v0.4.5), I went ahead and updated text in the release issue to match our updated infrastructure.

Since the workflow has been heavily tested with `edge` containers from this repo, I think this is really all we need to do before releasing (aka - please register your disagreements now!)