### PR TITLE
Add separate anndata test file

### DIFF
--- a/tests/testthat/test-sce_to_anndata.R
+++ b/tests/testthat/test-sce_to_anndata.R
@@ -93,10 +93,11 @@ test_that("Conversion of SCE to AnnData works as expected", {
 })
 
 test_that("Conversion of SCE to AnnData works with additional arguments", {
+  no_verbose_anndata_file <- file.path(tempdir, "no_verbose_anndata.h5")
   # test that the H5 file is created with additional options
   expect_snapshot_file({
     sce_to_anndata(sce, anndata_file, verbose = FALSE)
-    anndata_file
+    no_verbose_anndata_file
   })
 })
 

--- a/tests/testthat/test-sce_to_anndata.R
+++ b/tests/testthat/test-sce_to_anndata.R
@@ -96,7 +96,7 @@ test_that("Conversion of SCE to AnnData works with additional arguments", {
   no_verbose_anndata_file <- file.path(tempdir, "no_verbose_anndata.h5")
   # test that the H5 file is created with additional options
   expect_snapshot_file({
-    sce_to_anndata(sce, anndata_file, verbose = FALSE)
+    sce_to_anndata(sce, no_verbose_anndata_file, verbose = FALSE)
     no_verbose_anndata_file
   })
 })


### PR DESCRIPTION
Turns out we may have a slight bug in the test suite: https://github.com/AlexsLemonade/scpcaTools/actions/runs/23902390270/job/69710478784#step:7:308

I'm fixing this with a new file name, which should get around this error which is intermittent I think because of caching. I'll delete and re-do the 0.4.5 release to include this, assuming it indeed fixes things! 